### PR TITLE
Add Minion as module on Safes on deployment

### DIFF
--- a/src/components/Settings/NewMinionSafe.js
+++ b/src/components/Settings/NewMinionSafe.js
@@ -99,6 +99,7 @@ const NewMinionSafe = () => {
       createAndAddModules:
         supportedChains[network.network_id].safe_create_and_add_modules,
       safeMasterCopy: supportedChains[network.network_id].safe_master_copy,
+      moduleEnabler: supportedChains[network.network_id].module_enabler,
       network: network,
     };
     console.log('setupValues', setupValues);
@@ -112,7 +113,7 @@ const NewMinionSafe = () => {
 
     try {
       minionSafeService.setup(
-        values.applicantHidden,
+        values.applicant,
         values.minionAddress,
         txCallBack,
       );

--- a/src/utils/chains.js
+++ b/src/utils/chains.js
@@ -95,6 +95,7 @@ export const supportedChains = {
     safe_proxy_factory: '0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B',
     safe_create_and_add_modules: '0xF61A721642B0c0C8b334bA3763BA1326F53798C0',
     safe_master_copy: '0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F',
+    module_enabler: '0x10286225AE73546Dcf1BB51F4695610Ae1EE5CaD',
   },
 };
 

--- a/src/utils/minion-safe-service.js
+++ b/src/utils/minion-safe-service.js
@@ -89,7 +89,7 @@ export class MinionSafeService {
   async setup(delegateAddress, minionAddress, callback) {
     const Address0 = '0x'.padEnd(42, '0');
 
-    const threshhold = 2;
+    const threshold = 2;
     const mastercopy = this.safeMasterCopy;
 
     const cacheMinionSafe = {
@@ -112,7 +112,7 @@ export class MinionSafeService {
     const setupData = await this.safe.methods
       .setup(
         [delegateAddress, minionAddress],
-        threshhold,
+        threshold,
         mastercopy,
         createAndAddModulesData,
         Address0,

--- a/src/utils/minion-safe-service.js
+++ b/src/utils/minion-safe-service.js
@@ -62,31 +62,6 @@ export class MinionSafeService {
     );
   }
 
-  createAndAddModulesData(dataArray) {
-    const ModuleDataWrapper = new this.web3.eth.Contract([
-      {
-        constant: false,
-        inputs: [{ name: 'data', type: 'bytes' }],
-        name: 'setup',
-        outputs: [],
-        payable: false,
-        stateMutability: 'nonpayable',
-        type: 'function',
-      },
-    ]);
-
-    // Remove method id (10) and position of data in payload (64)
-    return dataArray.reduce(
-      (acc, data) =>
-        acc +
-        ModuleDataWrapper.methods
-          .setup(data)
-          .encodeABI()
-          .substr(74),
-      '0x',
-    );
-  }
-
   async setup(delegateAddress, minionAddress, callback) {
     const Address0 = '0x'.padEnd(42, '0');
 

--- a/src/utils/minion-safe-service.js
+++ b/src/utils/minion-safe-service.js
@@ -18,6 +18,7 @@ export class MinionSafeService {
     this.safeProxyFactory = setupValues.safeProxyFactory;
     this.createAndAddModulesAddress = setupValues.createAndAddModules;
     this.safeMasterCopy = setupValues.safeMasterCopy;
+    this.moduleEnabler = setupValues.moduleEnabler;
     this.network = setupValues.network;
     this.safeProxyFactoryContract = new web3.eth.Contract(
       safeProxyFactoryAbi,
@@ -101,20 +102,12 @@ export class MinionSafeService {
       .enableModule(minionAddress)
       .encodeABI();
 
-    const modulesCreationData = this.createAndAddModulesData([
-      enableModuleData,
-    ]);
-
-    const createAndAddModulesData = this.safeCreateAndAddModulesContract.methods
-      .createAndAddModules(this.safeProxyFactory, modulesCreationData)
-      .encodeABI();
-
     const setupData = await this.safe.methods
       .setup(
         [delegateAddress, minionAddress],
         threshold,
-        mastercopy,
-        createAndAddModulesData,
+        this.moduleEnabler,
+        enableModuleData,
         Address0,
         Address0,
         0,


### PR DESCRIPTION
On deployment, the Gnosis Safes will delegate call into the `ModuleEnabler` contract (as below) which will result in the Safe performing a call to its own `enableModule` function, whitelisting the Minion's address as a module.

```
// SPDX-License-Identifier: MIT
pragma solidity 0.8.0;

contract ModuleEnabler {
    function enableModule(address module) public {
        this.enableModule(module);
    }
}
```
This is deployed on XDai at [0x10286225AE73546Dcf1BB51F4695610Ae1EE5CaD](https://blockscout.com/poa/xdai/address/0x10286225AE73546Dcf1BB51F4695610Ae1EE5CaD/contracts)


Note: in `NewMinionSafe` I've changed it from passing `applicantHidden` to `applicant` to `setup` as I was getting an empty string being passed. Feel free to change back if this isn't a desired change.