### PR TITLE
chore: make entire explore card clickable

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,11 +36,14 @@ function App() {
         <Route exact path='/'>
           <Hub />
         </Route>
-        <Route exact path='/explore'>
-          <ExploreContextProvider>
-            <Explore />
-          </ExploreContextProvider>
-        </Route>
+        <Route
+          exact
+          path='/explore'
+          render={(rProps) => (
+            <ExploreContextProvider>
+              <Explore {...rProps} />
+            </ExploreContextProvider>)}
+        />
         <Route exact path='/summon'>
           <Summon />
         </Route>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,11 +39,11 @@ function App() {
         <Route
           exact
           path='/explore'
-          render={(rProps) => (
-            <ExploreContextProvider>
-              <Explore {...rProps} />
-            </ExploreContextProvider>)}
-        />
+        >
+          <ExploreContextProvider>
+            <Explore />
+          </ExploreContextProvider>
+        </Route>
         <Route exact path='/summon'>
           <Summon />
         </Route>

--- a/src/components/exploreCard.jsx
+++ b/src/components/exploreCard.jsx
@@ -60,7 +60,6 @@ const ExploreCard = ({ dao }) => {
       mt={5}
       style={{ transition: 'all .15s linear' }}
       _hover={{ transform: 'scale(1.05)', cursor: 'pointer' }}
-      // onClick={handleClick}
     >
       <Flex direction='row' align='center' w='100%'>
         <Avatar

--- a/src/components/exploreCard.jsx
+++ b/src/components/exploreCard.jsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import makeBlockie from 'ethereum-blockies-base64';
 import {
-  Avatar, Box, Flex, Button, Badge, Link, Text,
+  Avatar, Box, Flex, Button, Badge, Text, Link,
 } from '@chakra-ui/react';
-import { Link as RouterLink, withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import ContentBox from './ContentBox';
 import { ExploreContext } from '../contexts/ExploreContext';
 import { pokemolUrlExplore, themeImagePath } from '../utils/metadata';
@@ -21,7 +21,7 @@ const ExploreCard = ({ dao, history }) => {
     }
   };
 
-  const handleClick = () => history.push(`/dao/${chainByNetworkId(dao.networkId).chain_id}/${dao.id}`);
+  const handleClick = () => history.push(dao.meta.version === '1' ? pokemolUrlExplore(dao) : `/dao/${chainByNetworkId(dao.networkId).chain_id}/${dao.id}`);
 
   const renderTags = () => {
     if (dao.meta?.tags) {
@@ -72,7 +72,6 @@ const ExploreCard = ({ dao, history }) => {
         return (
           <Button
             minWidth='80px'
-            as={RouterLink}
             variant='outline'
           >
             Go

--- a/src/components/exploreCard.jsx
+++ b/src/components/exploreCard.jsx
@@ -3,14 +3,14 @@ import makeBlockie from 'ethereum-blockies-base64';
 import {
   Avatar, Box, Flex, Button, Badge, Text, Link,
 } from '@chakra-ui/react';
-import { withRouter } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import ContentBox from './ContentBox';
 import { ExploreContext } from '../contexts/ExploreContext';
 import { pokemolUrlExplore, themeImagePath } from '../utils/metadata';
 import { numberWithCommas } from '../utils/general';
 import { chainByNetworkId } from '../utils/chain';
 
-const ExploreCard = ({ dao, history }) => {
+const ExploreCard = ({ dao }) => {
   const { state, dispatch } = useContext(ExploreContext);
 
   const handleTagSelect = (tag) => {
@@ -20,8 +20,6 @@ const ExploreCard = ({ dao, history }) => {
       dispatch({ type: 'updateTags', payload: tagUpdate });
     }
   };
-
-  const handleClick = () => history.push(dao.meta.version === '1' ? pokemolUrlExplore(dao) : `/dao/${chainByNetworkId(dao.networkId).chain_id}/${dao.id}`);
 
   const renderTags = () => {
     if (dao.meta?.tags) {
@@ -52,45 +50,17 @@ const ExploreCard = ({ dao, history }) => {
     return null;
   };
 
-  const renderLink = (daoData) => {
-    switch (daoData.meta.version) {
-      case '1': {
-        return (
-          <Button
-            minWidth='80px'
-            as={Link}
-            variant='outline'
-            href={pokemolUrlExplore(dao)}
-            isExternal
-          >
-            Go
-          </Button>
-        );
-      }
-      case '2':
-      case '2.1': {
-        return (
-          <Button
-            minWidth='80px'
-            variant='outline'
-          >
-            Go
-          </Button>
-        );
-      }
-      default: {
-        return null;
-      }
-    }
-  };
   return (
     <ContentBox
+      as={dao.meta.version === '1' ? Link : RouterLink}
+      to={dao.meta.version.startsWith('2') ? `/dao/${chainByNetworkId(dao.networkId).chain_id}/${dao.id}` : null}
+      href={dao.meta.version === '1' ? pokemolUrlExplore(dao) : null}
       w={['100%', '100%', '100%', '340px', '340px']}
       h='340px'
       mt={5}
       style={{ transition: 'all .15s linear' }}
       _hover={{ transform: 'scale(1.05)', cursor: 'pointer' }}
-      onClick={handleClick}
+      // onClick={handleClick}
     >
       <Flex direction='row' align='center' w='100%'>
         <Avatar
@@ -160,10 +130,18 @@ const ExploreCard = ({ dao, history }) => {
 
       {renderTags()}
       <Flex justify='flex-end' w='100%'>
-        <Box mt={5}>{renderLink(dao)}</Box>
+        <Box mt={5}>
+          <Button
+            minWidth='80px'
+            variant='outline'
+          >
+            Go
+          </Button>
+
+        </Box>
       </Flex>
     </ContentBox>
   );
 };
 
-export default withRouter(ExploreCard);
+export default ExploreCard;

--- a/src/components/exploreCard.jsx
+++ b/src/components/exploreCard.jsx
@@ -3,14 +3,14 @@ import makeBlockie from 'ethereum-blockies-base64';
 import {
   Avatar, Box, Flex, Button, Badge, Link, Text,
 } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, withRouter } from 'react-router-dom';
 import ContentBox from './ContentBox';
 import { ExploreContext } from '../contexts/ExploreContext';
 import { pokemolUrlExplore, themeImagePath } from '../utils/metadata';
 import { numberWithCommas } from '../utils/general';
 import { chainByNetworkId } from '../utils/chain';
 
-const ExploreCard = ({ dao }) => {
+const ExploreCard = ({ dao, history }) => {
   const { state, dispatch } = useContext(ExploreContext);
 
   const handleTagSelect = (tag) => {
@@ -20,6 +20,8 @@ const ExploreCard = ({ dao }) => {
       dispatch({ type: 'updateTags', payload: tagUpdate });
     }
   };
+
+  const handleClick = () => history.push(`/dao/${chainByNetworkId(dao.networkId).chain_id}/${dao.id}`);
 
   const renderTags = () => {
     if (dao.meta?.tags) {
@@ -72,7 +74,6 @@ const ExploreCard = ({ dao }) => {
             minWidth='80px'
             as={RouterLink}
             variant='outline'
-            to={`/dao/${chainByNetworkId(dao.networkId).chain_id}/${dao.id}`}
           >
             Go
           </Button>
@@ -89,7 +90,8 @@ const ExploreCard = ({ dao }) => {
       h='340px'
       mt={5}
       style={{ transition: 'all .15s linear' }}
-      _hover={{ transform: 'scale(1.05)' }}
+      _hover={{ transform: 'scale(1.05)', cursor: 'pointer' }}
+      onClick={handleClick}
     >
       <Flex direction='row' align='center' w='100%'>
         <Avatar
@@ -165,4 +167,4 @@ const ExploreCard = ({ dao }) => {
   );
 };
 
-export default ExploreCard;
+export default withRouter(ExploreCard);


### PR DESCRIPTION
The explore card should now be entirely clickable and follows the exact versioning condition like how it was rendered for GO. I have removed the connection for the URL inside the GO button, but I can put it back if it feels a little odd. 