### PR TITLE
fix minions null value exception on page reload

### DIFF
--- a/src/pages/Boosts.jsx
+++ b/src/pages/Boosts.jsx
@@ -27,7 +27,7 @@ const Boosts = ({ customTerms, daoMember, daoOverview, daoMetaData }) => {
 
   const hasDependentBoost = boostKey => {
     if (boostKey === 'vanillaMinions') {
-      const minions = daoOverview.minions.length;
+      const minions = daoOverview?.minions.length;
       return minions;
     }
     const boostData = daoMetaData.boosts[boostKey];


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'minions' of null` when reloading the Boosts page