### PR TITLE
fix undefined value error for fresh sfminions with no started streams

### DIFF
--- a/src/services/superfluidMinionService.js
+++ b/src/services/superfluidMinionService.js
@@ -94,8 +94,8 @@ export const SuperfluidMinionService = ({ web3, minion, chainID }) => {
           const sfOutStreams = sfAccount?.account?.flowsOwned;
           const tokens = Array.from(
             new Set([
-              ...sfInStreams.map(s => s.token.id),
-              ...sfOutStreams.map(s => s.token.id),
+              ...(sfInStreams?.map(s => s.token.id) || []),
+              ...(sfOutStreams?.map(s => s.token.id) || []),
             ]),
           ).map(token => {
             const s =


### PR DESCRIPTION
This PR fixes the undefined value errors that cause a skeleton blinking on fresh sfminions with no in/out streams