### PR TITLE
CU-mex0xe: Add feature for custom abi

### DIFF
--- a/src/components/minionList.jsx
+++ b/src/components/minionList.jsx
@@ -49,6 +49,13 @@ const MinionList = () => {
           badgeTextColor: 'white',
           badgeName: 'UHS',
         };
+      case MINION_TYPES.NIFTY:
+        return {
+          minionUrlType: 'nifty-minion',
+          badgeColor: 'blue',
+          badgeTextColor: 'white',
+          badgeName: 'NIFTY',
+        };
       default:
         return {
           minionUrlType: 'minion',

--- a/src/forms/minionSimpleProposal.jsx
+++ b/src/forms/minionSimpleProposal.jsx
@@ -39,6 +39,7 @@ import PaymentInput from './paymentInput';
 const MinionProposalForm = () => {
   const [loading, setLoading] = useState(false);
   const [abiLoading, setAbiLoading] = useState(false);
+  const [toggleCustomAbi, setToggleCustomAbi] = useState(false);
   const { daoOverview } = useDao();
   const { daoMetaData } = useMetaData();
   const { daochain, daoid } = useParams();
@@ -246,8 +247,27 @@ const MinionProposalForm = () => {
     return localAbiFunctions;
   };
 
+  const handleABIDataBlur = e => {
+    try {
+      const { value } = e.target;
+      if (!value) return;
+      const abiFunctions = getFunctions(JSON.parse(value));
+      console.log(abiFunctions);
+      setCurrentError(null);
+      setAbiParams(null);
+      setAbiFunctions(abiFunctions);
+    } catch (err) {
+      setAbiParams(null);
+      setAbiFunctions(null);
+      setCurrentError(
+        err.name === 'SyntaxError' ? new Error('Invalid ABI Data') : err,
+      );
+    }
+  };
+
   const handleBlur = async e => {
     const { value } = e.target;
+    setToggleCustomAbi(false);
     setAbiLoading(true);
     try {
       const key =
@@ -259,6 +279,7 @@ const MinionProposalForm = () => {
 
       if (!json.result || json.status === '0') {
         const msg = daochain === '0x64' ? json.message : json.result;
+        setToggleCustomAbi(true);
         throw new Error(msg);
       }
       let parsed = JSON.parse(json.result);
@@ -282,6 +303,7 @@ const MinionProposalForm = () => {
 
         if (!json2.result || json2.status === '0') {
           const msg = daochain === '0x64' ? json2.message : json2.result;
+          setToggleCustomAbi(false);
           throw new Error(msg);
         }
         parsed = JSON.parse(json2.result);
@@ -425,6 +447,28 @@ const MinionProposalForm = () => {
             </>
           ) : (
             <>
+              {toggleCustomAbi && (
+                <>
+                  <TextBox as={FormLabel} size='xs' htmlFor='abiData'>
+                    Contract ABI
+                  </TextBox>
+                  <Textarea
+                    name='abiData'
+                    placeholder='Raw Hex Data'
+                    mb={5}
+                    h='8rem'
+                    ref={register({
+                      required: {
+                        value: true,
+                        message: 'Contract ABI is required',
+                      },
+                    })}
+                    color='white'
+                    focusBorderColor='secondary.500'
+                    onBlur={handleABIDataBlur}
+                  />
+                </>
+              )}
               <TextBox as={FormLabel} size='xs' htmlFor='abiFunctions'>
                 <Box mr={2}>ABI Functions</Box>
                 {abiLoading && <Spinner />}

--- a/src/forms/minionSimpleProposal.jsx
+++ b/src/forms/minionSimpleProposal.jsx
@@ -252,7 +252,6 @@ const MinionProposalForm = () => {
       const { value } = e.target;
       if (!value) return;
       const abiFunctions = getFunctions(JSON.parse(value));
-      console.log(abiFunctions);
       setCurrentError(null);
       setAbiParams(null);
       setAbiFunctions(abiFunctions);


### PR DESCRIPTION
We now have an option to provide custom ABI data if the contract from EtherScan is not verified. 

https://user-images.githubusercontent.com/32637757/122619772-d1f03780-d0ae-11eb-8669-eae0138ad1cc.mov

Also added the NIFTY_MINION type in minionList.