### PR TITLE
Fix medium link

### DIFF
--- a/src/forms/daoMetaForm.jsx
+++ b/src/forms/daoMetaForm.jsx
@@ -264,7 +264,7 @@ const DaoMetaForm = ({ metadata, handleUpdate }) => {
                     </InputGroup>
                   </FormControl>
 
-                  <FormControl id='medium' mb={4}>
+                  <FormControl id='other' mb={4}>
                     <InputGroup>
                       <InputLeftAddon bg='transparent'>
                         <AiFillQuestionCircle />


### PR DESCRIPTION
Medium link on hausDAO wasn't working properly: anything entered into the field would have "https://medium.com" prepended to it. Found the source of the bug and fixed it in this PR.