### PR TITLE
Fix NaN when a non-member hovers info-icon

### DIFF
--- a/src/components/proposalActions.jsx
+++ b/src/components/proposalActions.jsx
@@ -191,6 +191,11 @@ const ProposalVote = ({
     setLoading(false);
   };
 
+  const getCurrentMemberFunds = () => {
+    if (!daoMember) return 0;
+    return Number(daoMember?.depositTokenBalance)?.toFixed(3);
+  };
+
   return (
     <>
       <ContentBox position='relative'>
@@ -224,9 +229,9 @@ const ProposalVote = ({
                     <Tooltip
                       shouldWrapChildren
                       placement='bottom'
-                      label={`Insufficient Funds: You only have ${Number(
-                        daoMember?.depositTokenBalance,
-                      )?.toFixed(3)} ${overview?.depositToken?.symbol}`}
+                      label={`Insufficient Funds: You only have ${getCurrentMemberFunds()} ${
+                        overview?.depositToken?.symbol
+                      }`}
                     >
                       <Icon
                         color='red.500'

--- a/src/components/proposalActions.jsx
+++ b/src/components/proposalActions.jsx
@@ -191,11 +191,6 @@ const ProposalVote = ({
     setLoading(false);
   };
 
-  const getCurrentMemberFunds = () => {
-    if (!daoMember) return 0;
-    return Number(daoMember?.depositTokenBalance)?.toFixed(3);
-  };
-
   return (
     <>
       <ContentBox position='relative'>
@@ -225,13 +220,13 @@ const ProposalVote = ({
                   {`${overview?.proposalDeposit /
                     10 ** overview?.depositToken.decimals}
                   ${overview?.depositToken?.symbol}`}
-                  {!enoughDeposit ? (
+                  {!enoughDeposit && daoMember ? (
                     <Tooltip
                       shouldWrapChildren
                       placement='bottom'
-                      label={`Insufficient Funds: You only have ${getCurrentMemberFunds()} ${
-                        overview?.depositToken?.symbol
-                      }`}
+                      label={`Insufficient Funds: You only have ${Number(
+                        daoMember?.depositTokenBalance,
+                      )?.toFixed(3)} ${overview?.depositToken?.symbol}`}
                     >
                       <Icon
                         color='red.500'


### PR DESCRIPTION
Replace `NaN` when a non-member of the DAO hovers the info-icon next to *DEPOSIT TO SPONSOR* value.

[Image](https://tinypix.top/images/2021/08/18/v9bep.png)
