### PR TITLE
close HausDAO/haus-tasks#19 - clear search term on DAO switcher close

### DIFF
--- a/src/modals/daoSwitcherModal.jsx
+++ b/src/modals/daoSwitcherModal.jsx
@@ -74,6 +74,7 @@ const DaoSwitcherModal = () => {
   };
 
   const handleClose = () => {
+    setSearchTerm(null);
     setDaoSwitcherModal(false);
   };
 


### PR DESCRIPTION
New behavior is to set search term to false on DAO switcher modal close

*On open*
![1](https://user-images.githubusercontent.com/81343175/133947198-5de92ea2-b81b-493f-a067-68de2fdec6df.png)

*On list change*
![2](https://user-images.githubusercontent.com/81343175/133947201-59e2236a-509b-4e56-8319-1d6ccc0b8fb8.png)

*On reopen*
![3](https://user-images.githubusercontent.com/81343175/133947211-f1fb6d21-78db-48fb-bf78-206ee3568031.png)
