### PR TITLE
Add validations on ragequit & summon minion safe

### DIFF
--- a/src/data/forms.js
+++ b/src/data/forms.js
@@ -75,7 +75,7 @@ export const CORE_FORMS = {
     fields: [[FIELD.MINION_TYPE_SELECT]],
   },
   RAGE_QUIT: {
-    customValidations: ['rageQuitMinimum', 'rageQuitMax'],
+    customValidations: ['canRagequit', 'rageQuitMinimum', 'rageQuitMax'],
     id: 'RAGE_QUIT',
     title: 'RAGE QUIT',
     required: [],
@@ -445,6 +445,7 @@ export const FORM = {
     fields: [[FIELD.MINION_NAME, FIELD.MINION_QUORUM, FIELD.SALT_NONCE]],
   },
   NEW_SAFE_MINION_ADVANCED: {
+    customValidations: ['noExistingSafeMinion'],
     required: ['minionName', 'safeAddress', 'minQuorum', 'saltNonce'],
     tx: TX.SUMMON_MINION_SAFE,
     fields: [

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -134,6 +134,20 @@ export const customValidations = {
     }
     return false;
   },
+  canRagequit({ appState }) {
+    const { proposalId } = appState.daoMember.highestIndexYesVote;
+    const proposal = appState.daoProposals.find(
+      p => p.proposalId === proposalId,
+    );
+    if (proposal && !proposal.processed) {
+      return {
+        name: 'shares',
+        message:
+          'Cannot process this request until all pending proposal that voted YES are processed',
+      };
+    }
+    return false;
+  },
   rageQuitMinimum({ values }) {
     if (!Number(values.shares) && !Number(values.loot)) {
       return {
@@ -144,14 +158,14 @@ export const customValidations = {
     return false;
   },
   rageQuitMax({ appState, values }) {
-    if (values.shares > appState.daoMember.shares) {
+    if (+values.shares > +appState.daoMember.shares) {
       return {
         name: 'shares',
         message: `Shares to Rage Quit may not exceed ${appState.daoMember.shares}.`,
       };
     }
 
-    if (values.loot > appState.daoMember.loot) {
+    if (+values.loot > +appState.daoMember.loot) {
       return {
         name: 'loot',
         message: `Loot to Rage Quit may not exceed ${appState.daoMember.loot} loot.`,
@@ -189,6 +203,19 @@ export const customValidations = {
           message: 'Payment must be less than the DAO balance.',
         };
       }
+    }
+    return false;
+  },
+  noExistingSafeMinion({ appState, values }) {
+    const { minions } = appState.daoOverview;
+    const foundSafe = minions?.find(
+      m => m.safeAddress === values.safeAddress.toLowerCase(),
+    );
+    if (foundSafe) {
+      return {
+        name: 'safeAddress',
+        message: 'This Gnosis Safe has already been assigned to a Minion',
+      };
     }
     return false;
   },

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -104,7 +104,7 @@ export const customValidations = {
   },
   superFluidStreamMinimum({ values }) {
     const minDeposit = Web3.utils.toWei(values.paymentRequested);
-    if (+minDeposit < +values.weiRatePerSec * 3600) {
+    if (Number(minDeposit) < Number(values.weiRatePerSec) * 3600) {
       return {
         name: 'paymentRequested',
         message: 'Funds requested must be at least one-hour of stream value',
@@ -116,7 +116,7 @@ export const customValidations = {
     const { daoMember } = appState;
     const { tributeOffered } = values;
     // TODO allowance should be tracked by token. but lazy check based on dropdown?
-    if (+tributeOffered > +daoMember.allowance) {
+    if (Number(tributeOffered) > Number(daoMember.allowance)) {
       return {
         name: 'tributeOffered',
         message: 'Please unlock the tribute token.',
@@ -158,14 +158,14 @@ export const customValidations = {
     return false;
   },
   rageQuitMax({ appState, values }) {
-    if (+values.shares > +appState.daoMember.shares) {
+    if (Number(values.shares) > Number(appState.daoMember.shares)) {
       return {
         name: 'shares',
         message: `Shares to Rage Quit may not exceed ${appState.daoMember.shares}.`,
       };
     }
 
-    if (+values.loot > +appState.daoMember.loot) {
+    if (Number(values.loot) > Number(appState.daoMember.loot)) {
       return {
         name: 'loot',
         message: `Loot to Rage Quit may not exceed ${appState.daoMember.loot} loot.`,
@@ -176,11 +176,11 @@ export const customValidations = {
   enoughBalance({ appState, values }) {
     const { daoMember } = appState;
     const { tributeOffered, tributeToken } = values;
-    if (+tributeOffered > 0) {
+    if (Number(tributeOffered) > 0) {
       const token = daoMember.tokenBalances.find(
         t => t.token.tokenAddress === tributeToken,
       );
-      if (+tributeOffered > +token.tokenBalance) {
+      if (Number(tributeOffered) > Number(token.tokenBalance)) {
         return {
           name: 'tributeOffered',
           message: 'Tribute must be less than your balance.',
@@ -192,12 +192,12 @@ export const customValidations = {
   enoughDaoBalance({ appState, values }) {
     const { daoOverview } = appState;
     const { paymentRequested, paymentToken } = values;
-    if (+paymentRequested > 0) {
+    if (Number(paymentRequested) > 0) {
       const token = daoOverview.tokenBalances.find(
         t => t.token.tokenAddress === paymentToken,
       );
       console.log(token);
-      if (+paymentRequested > +token.tokenBalance) {
+      if (Number(paymentRequested) > Number(token.tokenBalance)) {
         return {
           name: 'paymentRequested',
           message: 'Payment must be less than the DAO balance.',


### PR DESCRIPTION
Add validations to the following forms:

* **RageQuit**: a couple of issues came up during the `How to DAO` course that didn't allow to do a ragequit demo:
  * Failed to validate shares/loot values properly
  * On submit, got a Tx error message on the wallet but wasn't very informative. The reason was that the member has voted yes on proposals that are still waiting to be processed. To solve this, added a `canRagequit` validation
* **Summon MinionSafe** in advanced mode: `noExistingSafeMinion ` validation function to check if a gnosis safe isn't already assigned to a minion summoned by the current DAO