### PR TITLE
Feature/minion manual refresh

### DIFF
--- a/src/components/balanceList.jsx
+++ b/src/components/balanceList.jsx
@@ -34,9 +34,7 @@ const BalanceList = ({
         <TextBox size='xs' mb={6}>
           {balanceListTitle}
         </TextBox>
-        {!isNativeToken && !isTreasury && balances?.length > 0 && (
-          <MinionVaultRefreshButton />
-        )}
+        {!isNativeToken && !isTreasury && <MinionVaultRefreshButton />}
       </Flex>
       <Flex w='100%'>
         <Box w='25%' d={['none', null, null, 'inline-block']}>

--- a/src/components/minionVaultRefreshButton.jsx
+++ b/src/components/minionVaultRefreshButton.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { RiRefreshLine } from 'react-icons/ri';
 import { useParams } from 'react-router';
-import { IconButton } from '@chakra-ui/react';
+import { IconButton, Spinner } from '@chakra-ui/react';
 
 import { useDao } from '../contexts/DaoContext';
 import { useDaoMember } from '../contexts/DaoMemberContext';
@@ -12,25 +12,20 @@ const MinionVaultRefreshButton = () => {
   const { isMember } = useDaoMember();
   const { refreshMinionVault } = useDao();
   const { refreshDao } = useTX();
-  const [hideRefresh, setHideRefresh] = useState(false);
-
-  useEffect(() => {
-    if (hideRefresh) {
-      // hide the button after a refresh to support rate limiting/prevent overloading the lambda
-      const interval = setInterval(() => {
-        setHideRefresh(false);
-      }, 600000);
-      return () => clearInterval(interval);
-    }
-  }, [hideRefresh]);
+  const [loading, setLoading] = useState(false);
 
   const handleRefreshMinion = async () => {
-    setHideRefresh(true);
+    setLoading(true);
     await refreshMinionVault(minion);
     refreshDao();
+    setLoading(false);
   };
 
-  if (!isMember || hideRefresh || !minion) {
+  if (loading) {
+    return <Spinner size='md' color='secondary.400' />;
+  }
+
+  if (!isMember || !minion) {
     return null;
   }
 


### PR DESCRIPTION
Removes rate limiter on the refresh button under tokens on the minion vault page. Also allows refresh when there are 0 balances.

*The rate limiter was previously set to 10min "to support rate limiting/prevent overloading the lambda" however not sure if this is necessary. Looking for additional review on this.*