### PR TITLE
Bug: Proposal component does not update when "Needs Processing Next" button is pressed

### DIFF
--- a/src/pages/Proposal.jsx
+++ b/src/pages/Proposal.jsx
@@ -65,7 +65,7 @@ const Proposal = ({
     if (activities && propid.match(/^\d+$/)) {
       setUpProposal();
     }
-  }, [activities]);
+  }, [activities, propid]);
 
   console.log('currentProposal', currentProposal);
 


### PR DESCRIPTION
I'm in the current Raid Guild Season 3 cohort and noticed a bug where page content did not update when it should. I also submitted this bug via clickup per instructions on the README. Info below is also on the ClickUp form. I have tested this fix though and it appears to fix this issue.

When clicking "Proposal `<nextProposalId>` Needs Processing Next", the page content does not update. The issue appears to be that the useEffect was not executing on change of the `propid` (pulled from the `path`).

The state of the DAO has now changed (there are no passed proposals in the queue for processing), so unfortunately it is harder to repro, but a link a found this at was: 

https://app.daohaus.club/dao/0x64/0x7bde8f8a3d59b42d0d8fab3a46e9f42e8e3c2de8/proposals/43

To repro:

Create 2 proposals that have both passed, go to the URL for the proposal that is not next (e.g. propid 43 in the screenshot), click on the button that says "Proposal 42 Needs Processing Next" (assuming 42 is next proposal ID). The URL will change to ".../42", but the page content does not update. 

![proposal_needs_processing_next_bug](https://user-images.githubusercontent.com/92540752/142687230-0b777e92-882c-46f9-be5b-c6bc55d41230.png)
