### PR TITLE
Adds Switch for Optional Sale Duration

### DIFF
--- a/src/data/fields.js
+++ b/src/data/fields.js
@@ -214,6 +214,19 @@ export const FIELD = {
     label: 'Vaild Rarible Order Data',
     expectType: 'any',
   },
+  DATE_RANGE_SWITCH: {
+    type: 'toggleForm',
+    listenTo: 'formCondition',
+    checked: 'fixed',
+    unchecked: 'unset',
+    label: {
+      type: 'formCondition',
+      fixed: 'Fixed Length',
+      unset: 'Unset',
+    },
+    title: 'Auction Duration',
+    expectType: 'any',
+  },
   NFT_INPUT: {
     type: 'input',
     htmlFor: 'nftAddress',
@@ -243,7 +256,7 @@ export const FIELD = {
     type: 'dateRange',
     htmlFor: 'dateRange',
     name: 'dateRange',
-    label: 'Set Auction Duration',
+    label: 'Set Date Range',
     expectType: 'any',
   },
   DELEGATE_ADDRESS: {

--- a/src/data/forms.js
+++ b/src/data/forms.js
@@ -547,6 +547,7 @@ export const PROPOSAL_FORMS = {
   },
   SELL_NFT_RARIBLE: {
     id: 'SELL_NFT_RARIBLE',
+    formConditions: ['unset', 'fixed'],
     title: 'Sell NFT on Rarible',
     description: 'Post an NFT for sale on Rarible',
     type: PROPOSAL_TYPES.SELL_NFT_RARIBLE,
@@ -556,7 +557,12 @@ export const PROPOSAL_FORMS = {
     fields: [
       [FIELD.NFT_SELECT],
       [
-        FIELD.DATE_RANGE,
+        FIELD.DATE_RANGE_SWITCH,
+        {
+          type: 'formCondition',
+          fixed: FIELD.DATE_RANGE,
+          unset: null,
+        },
         {
           ...FIELD.SET_PRICE,
           orderType: 'sell',


### PR DESCRIPTION
Add a switch to the Rarible Sell order to toggle the Date Range input. If unset (default), the sale order is valid indefinitely which is most likely the most common use case.