### PR TITLE
Fix exception when whitelisted tokens are from wrong network

### DIFF
--- a/src/contexts/TokenContext.jsx
+++ b/src/contexts/TokenContext.jsx
@@ -28,6 +28,7 @@ export const TokenProvider = ({ children }) => {
   useEffect(() => {
     const initDaoTokens = async () => {
       const newDaoData = await initTokenData(
+        daochain,
         daoOverview.tokenBalances,
         setTokenPrices,
       );
@@ -56,7 +57,7 @@ export const TokenProvider = ({ children }) => {
   }, [currentDaoTokens, daochain]);
 
   const refetchTokens = async () => {
-    const newDaoData = await initTokenData(daoOverview.tokenBalances);
+    const newDaoData = await initTokenData(daochain, daoOverview.tokenBalances);
     setCurrentDaoTokens(newDaoData);
     shouldFetchContract.current = true;
   };

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -47,7 +47,7 @@ const Profile = ({ members, overview, daoTokens, activities }) => {
 
   useEffect(() => {
     const initMemberTokens = async tokensWithBalance => {
-      const newTokenData = await initTokenData(tokensWithBalance);
+      const newTokenData = await initTokenData(daochain, tokensWithBalance);
       setTokensReceivable(newTokenData);
     };
     if (memberEntity?.tokenBalances && daochain) {

--- a/src/pages/SuperfluidMinion.jsx
+++ b/src/pages/SuperfluidMinion.jsx
@@ -92,7 +92,7 @@ const SuperfluidMinionDetails = ({
     const setUpBalances = async () => {
       const balances = members.find(member => member.memberAddress === minion);
       const newTokenData = balances
-        ? await initTokenData(balances.tokenBalances)
+        ? await initTokenData(daochain, balances.tokenBalances)
         : [];
       setMinionBalances(newTokenData);
     };

--- a/src/utils/tokenValue.js
+++ b/src/utils/tokenValue.js
@@ -4,6 +4,7 @@ import { omit } from './general';
 import { validate } from './validation';
 import { createContract } from './contract';
 import { LOCAL_ABI } from './abi';
+import { chainByID } from './chain';
 
 const babe = '0x000000000000000000000000000000000000baBe';
 const tokenAPI =
@@ -22,22 +23,30 @@ export const calcTotalUSD = (decimals, tokenBalance, usdVal) => {
   return (+tokenBalance / 10 ** decimals) * +usdVal;
 };
 
-export const initTokenData = async (graphTokenData, tokenPriceSetter) => {
+export const initTokenData = async (
+  daochain,
+  graphTokenData,
+  tokenPriceSetter,
+) => {
   const tokenData = await fetchTokenData();
   if (tokenData && tokenPriceSetter) {
     tokenPriceSetter(tokenData);
   }
 
+  const network = chainByID(daochain).networkAlt || chainByID(daochain).network;
+
   return graphTokenData
     .map(tokenObj => {
       const { token, tokenBalance } = tokenObj;
+      const tokenMeta =
+        tokenData[token.tokenAddress]?.network === network &&
+        tokenData[token.tokenAddress];
 
-      const usdVal = tokenData[token.tokenAddress]?.price || 0;
+      const usdVal = tokenMeta?.price || 0;
       // TODO: overriding due to dupe grt found in cache job
-      const symbol = tokenData[token.tokenAddress]?.symbol || token.symbol;
-      // const symbol = tokenData[token.tokenAddress]?.symbol || null;
-      const logoUri = tokenData[token.tokenAddress]?.logoURI || null;
-      const tokenName = tokenData[token.tokenAddress]?.name || null;
+      const symbol = tokenMeta?.symbol || token.symbol;
+      const logoUri = tokenMeta?.logoURI || null;
+      const tokenName = tokenMeta?.name || null;
       const tokenDataObj = {
         ...omit('token', tokenObj),
         ...token,


### PR DESCRIPTION
Fixes a runtime exception when opening the Treasury view on DAOs where members whitelisted tokens that don't exist on the chain the DAO lives. Example https://app.daohaus.club/dao/0x64/0x1b975a9daf25e7b01e0a6c72d657ff74925327a8/vaults/treasury