### PR TITLE
Update chain name for Gnosis Chain

### DIFF
--- a/src/utils/chain.js
+++ b/src/utils/chain.js
@@ -143,10 +143,10 @@ export const supportedChains = {
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
   },
   '0x64': {
-    name: 'xDAI Chain',
-    short_name: 'xdai',
+    name: 'Gnosis Chain',
+    short_name: 'gc',
     nativeCurrency: 'xDai',
-    network: 'xdai',
+    network: 'gnosis',
     network_id: 100,
     chain_id: '0x64',
     hub_sort_order: 2,

--- a/src/utils/chain.js
+++ b/src/utils/chain.js
@@ -146,7 +146,7 @@ export const supportedChains = {
     name: 'Gnosis Chain',
     short_name: 'gc',
     nativeCurrency: 'xDai',
-    network: 'gnosis',
+    network: 'xdai',
     network_id: 100,
     chain_id: '0x64',
     hub_sort_order: 2,


### PR DESCRIPTION
**Issue**
Recently the xDai chain has been rebranded to Gnosis Chain. The current main app display still shows 'xDai Chain' when connected to this chain. 

**Fix**
Updates `chain.js` data to "Gnosis Chain" with network name of `gnosis` and short_name of `gc`.
