### PR TITLE
fix/mobile-more-details

### DIFF
--- a/src/proposalBuilder/proposalBrief.jsx
+++ b/src/proposalBuilder/proposalBrief.jsx
@@ -16,6 +16,8 @@ const ProposalCardBrief = ({ proposal = {}, minionAction }) => {
     Number(proposal.paymentRequested) > 0;
   const { customTransferUI } = CUSTOM_CARD_DATA[proposal.proposalType] || {};
 
+  const { daochain, daoid } = useParams();
+
   return (
     <Flex
       width={['100%', '100%', '60%']}
@@ -59,6 +61,8 @@ const ProposalCardBrief = ({ proposal = {}, minionAction }) => {
         )}
         <Flex display={['flex', 'flex', 'none']} mb='3'>
           <Button
+            as={Link}
+            to={`/dao/${daochain}/${daoid}/proposals/${proposal.proposalId}`}
             variant='outline'
             size='sm'
             width='10rem'


### PR DESCRIPTION
This PR makes the `More Details` button link to the proposal by adding the `as` prop to pass in a `Link` with the `to` set to the proposal.

This seems to resolve the issue explained in [Discord
](https://discord.com/channels/709210493549674598/735524730328711188/945583966344318976). 

I was able to replicate the original issue using dev tools and this fix works.

![mobile-more-details](https://user-images.githubusercontent.com/9438776/155171519-5d5c2588-afd8-4414-a94d-fe7c94f003c1.gif)
