### PR TITLE
fix gnosis safe chain prefix

### DIFF
--- a/src/utils/chain.js
+++ b/src/utils/chain.js
@@ -181,6 +181,7 @@ export const supportedChains = {
   '0x64': {
     name: 'Gnosis Chain',
     short_name: 'gc',
+    shortNamePrefix: 'gno',
     nativeCurrency: 'xDai',
     network: 'xdai',
     network_id: 100,


### PR DESCRIPTION
Fix GnosisChain name prefix used on external gnosis safe URLs