### PR TITLE
fix eslint react plugin error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,9 +9,7 @@ module.exports = {
   // prettier should be last
   extends: [
     'eslint:recommended',
-    'airbnb',
     'plugin:prettier/recommended',
-    'plugin:react/recommended',
   ],
   globals: {
     Atomics: 'readonly',
@@ -35,7 +33,7 @@ module.exports = {
       configFile: './babel.config.json',
     },
   },
-  plugins: ['react-hooks', 'react'],
+  plugins: ['react-hooks'],
   settings: {
     react: {
       version: 'detect',


### PR DESCRIPTION
## Changes

Fixes the following eslint error: `ERROR in Plugin "react" was conflicted between ".eslintrc.js » plugin:react/recommended" and "BaseConfig » /home/jord/Documents/repos/pokemol-web/node_modules/eslint-config-react-app/base.js"`

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
