### PR TITLE
Fix funding proposal MAX input rounding

### DIFF
--- a/src/formBuilder/paymentInput.jsx
+++ b/src/formBuilder/paymentInput.jsx
@@ -26,9 +26,9 @@ const PaymentInput = props => {
   const paymentToken = watch('paymentToken');
   const maxBtnDisplay = useMemo(() => {
     if (validate.number(token?.balance) || token?.balance === 0) {
-      return `Max: ${handleDecimals(token.balance, token.decimals)?.toFixed(
-        4,
-      )}`;
+      return `Max: ${Math.floor(
+        handleDecimals(token.balance, token.decimals) * 10_000,
+      ) / 10_000}`;
     }
     return 'Error: Not found.';
   }, [token]);
@@ -75,7 +75,11 @@ const PaymentInput = props => {
 
   const setMax = () => {
     if (!token?.balance) return;
-    setValue('paymentRequested', token.balance / 10 ** token.decimals);
+    setValue(
+      'paymentRequested',
+      Math.floor(handleDecimals(token.balance, token.decimals) * 10_000) /
+        10_000,
+    );
   };
 
   const options = spreadOptions({


### PR DESCRIPTION
## GitHub Issue

[Add a link to the GitHub issue.](https://github.com/HausDAO/daohaus-app/issues/1766)

## Changes

Changes `setMax` to fill the `paymentRequested` form field with the same value shown in the "MAX" button. Also changes MAX value to be rounded down to the fourth decimal place. 

Changes seem to be constrained to the `PaymentInput` component, but lmk if I missed anything!

<img width="794" alt="Screen Shot 2022-04-17 at 18 10 39" src="https://user-images.githubusercontent.com/16960054/163739628-cced59e7-c438-4b05-9bc9-a1b00641f6a4.png">

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
