### PR TITLE
fix max token balance precision

### DIFF
--- a/src/formBuilder/paymentInput.jsx
+++ b/src/formBuilder/paymentInput.jsx
@@ -6,7 +6,7 @@ import ModButton from './modButton';
 
 import { getContractBalance } from '../utils/tokenValue';
 import { validate } from '../utils/validation';
-import { handleDecimals } from '../utils/general';
+import { handleBNDecimals, handleDecimals } from '../utils/general';
 import { spreadOptions } from '../utils/formBuilder';
 
 const PaymentInput = props => {
@@ -75,7 +75,10 @@ const PaymentInput = props => {
 
   const setMax = () => {
     if (!token?.balance) return;
-    setValue('paymentRequested', token.balance / 10 ** token.decimals);
+    setValue(
+      'paymentRequested',
+      handleBNDecimals(token.balance, token.decimals),
+    );
   };
 
   const options = spreadOptions({

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -320,6 +320,11 @@ export const handleDecimals = (balance, decimals, fallback = '--') => {
   return Number(balance) / 10 ** Number(decimals);
 };
 
+export const handleBNDecimals = (balance, decimals, fallback = '--') => {
+  if (!balance || !decimals) return fallback;
+  return utils.formatUnits(balance, decimals).toString();
+};
+
 export const handlePossibleNumber = (val, comma = true, roundAmt = 4) => {
   if (val == null) return;
   if (validate.number(val)) {


### PR DESCRIPTION
## GitHub Issue

Solves #1766 

## Changes

There's a precision issue when using JS Number object to get the max token balance as it truncates the value at some point. So I added a util function using ethers BN library so the exact balance is set when clicking on the Max button.

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
