### PR TITLE
Adds Moloch Token boost

### DIFF
--- a/src/components/daoContractSettings.jsx
+++ b/src/components/daoContractSettings.jsx
@@ -25,6 +25,7 @@ const DaoContractSettings = ({
   overview,
   customTerms,
   wrapNZap,
+  molochToken,
   transmutationContract,
 }) => {
   const { daochain, daoid } = useParams();
@@ -34,10 +35,12 @@ const DaoContractSettings = ({
   });
   const { successToast } = useOverlay();
 
-  const copiedToast = () => {
+  const copiedToast = (copiedAddressText, wrapNZap) => {
     successToast({
-      title: 'Copied Wrap-N-Zap address!',
-      description: `ONLY SEND ${supportedChains[daochain].nativeCurrency} TO THIS ADDRESS!`,
+      title: `Copied ${copiedAddressText} address!`,
+      description:
+        wrapNZap &&
+        `ONLY SEND ${supportedChains[daochain].nativeCurrency} TO THIS ADDRESS!`,
     });
   };
 
@@ -74,7 +77,29 @@ const DaoContractSettings = ({
                 <CopyToClipboard
                   text={wrapNZap}
                   mx={2}
-                  onCopy={copiedToast}
+                  onCopy={() => copiedToast('Wrap-N-Zap', true)}
+                  _hover={{ cursor: 'pointer' }}
+                >
+                  <Icon
+                    as={FaCopy}
+                    color='secondarytransmutationRes.transmutations[0].300'
+                    ml={2}
+                  />
+                </CopyToClipboard>
+              </Flex>
+            </Box>
+          </Flex>
+        )}
+        {molochToken && (
+          <Flex justify='space-between'>
+            <TextBox size='xs'>Moloch Token</TextBox>
+            <Box fontFamily='mono' variant='value' fontSize='sm'>
+              <Flex color='secondary.400' align='center'>
+                <Box>{molochToken}</Box>
+                <CopyToClipboard
+                  text={molochToken}
+                  mx={2}
+                  onCopy={() => copiedToast('Moloch Token')}
                   _hover={{ cursor: 'pointer' }}
                 >
                   <Icon

--- a/src/contracts/molochTokenFactory.json
+++ b/src/contracts/molochTokenFactory.json
@@ -1,0 +1,64 @@
+[
+  {
+    "type": "constructor",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "_template",
+        "internalType": "address payable"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "MolochTokenCreated",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "molochToken",
+        "internalType": "address",
+        "indexed": false
+      },
+      {
+        "type": "address",
+        "name": "moloch",
+        "internalType": "address",
+        "indexed": false
+      },
+      {
+        "type": "string",
+        "name": "name",
+        "internalType": "string",
+        "indexed": false
+      },
+      {
+        "type": "string",
+        "name": "symbol",
+        "internalType": "string",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [{ "type": "address", "name": "", "internalType": "address" }],
+    "name": "summonMolochToken",
+    "inputs": [
+      { "type": "address", "name": "_moloch", "internalType": "address" },
+      { "type": "string", "name": "_name", "internalType": "string" },
+      { "type": "string", "name": "_symbol", "internalType": "string" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [
+      { "type": "address", "name": "", "internalType": "address payable" }
+    ],
+    "name": "template",
+    "inputs": []
+  }
+]

--- a/src/data/boosts.js
+++ b/src/data/boosts.js
@@ -282,6 +282,18 @@ export const CONTENT = {
       { href: 'https://github.com/onPoster', label: 'Poster Github' },
     ],
   },
+  MOLOCH_TOKEN: {
+    title: 'Moloch Token',
+    description: 'Wrap DAO shares in ERC20 token for use in tooling',
+    publisher: PUBLISHERS.DAOHAUS,
+    version: '0.1',
+    pars: [
+      'Moloch Token gives DAOs an easy way to use DAO tooling with ERC20 support',
+    ],
+    externalLinks: [
+      { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
+    ],
+  },
 };
 
 export const COMMON_STEPS = {
@@ -374,6 +386,17 @@ export const STEPS = {
       form: FORM.WRAP_N_ZAP_LAUNCH,
       next: { type: 'awaitTx', then: 'STEP2', ctaText: 'Deploy' },
       stepLabel: 'Deploy Wrap n Zap',
+      isUserStep: true,
+    },
+    STEP2: COMMON_STEPS.SIGNER,
+  },
+  ADD_MOLOCH_TOKEN: {
+    DISPLAY: COMMON_STEPS.DISPLAY,
+    STEP1: {
+      type: 'form',
+      form: FORM.MOLOCH_TOKEN_LAUNCH,
+      next: { type: 'awaitTx', then: 'STEP2', ctaText: 'Deploy' },
+      stepLabel: 'Deploy Moloch Token',
       isUserStep: true,
     },
     STEP2: COMMON_STEPS.SIGNER,
@@ -645,6 +668,15 @@ export const BOOSTS = {
       type: 'internalLink',
       appendToDaoPath: 'docs',
     },
+  },
+  MOLOCH_TOKEN: {
+    id: 'MOLOCH_TOKEN',
+    boostContent: CONTENT.MOLOCH_TOKEN,
+    steps: STEPS.ADD_MOLOCH_TOKEN,
+    categories: ['tooling', 'community'],
+    networks: 'all',
+    cost: 'free',
+    settings: 'none',
   },
 };
 

--- a/src/data/contracts.js
+++ b/src/data/contracts.js
@@ -221,4 +221,9 @@ export const CONTRACTS = {
     abiName: 'AMB',
     conractAddress: '.localValues.ambAddress',
   },
+  MOLOCH_TOKEN_FACTORY: {
+    location: 'local',
+    abiName: 'MOLOCH_TOKEN_FACTORY',
+    contractAddress: '.contextData.chainConfig.moloch_token_factory',
+  },
 };

--- a/src/data/fields.js
+++ b/src/data/fields.js
@@ -621,6 +621,22 @@ export const FIELD = {
     label: 'WalletConnect Link',
     expectType: 'any',
   },
+  TOKEN_NAME: {
+    type: 'input',
+    label: 'Name',
+    name: 'token_name',
+    htmlFor: 'token_name',
+    placeholder: 'Token Name',
+    expectType: 'any',
+  },
+  TOKEN_SYMBOL: {
+    type: 'input',
+    label: 'Symbol',
+    name: 'token_symbol',
+    htmlFor: 'token_symbol',
+    placeholder: 'Token Symbol',
+    expectType: 'any',
+  },
 };
 
 export const FORM_DISPLAY = {

--- a/src/data/formLegos/customBoostInstall.js
+++ b/src/data/formLegos/customBoostInstall.js
@@ -171,4 +171,11 @@ export const CUSTOM_BOOST_INSTALL_FORMS = {
       ],
     ],
   },
+  MOLOCH_TOKEN_LAUNCH: {
+    id: 'MOLOCH_TOKEN_LAUNCH',
+    title: 'Deploy Moloch Token',
+    fields: [[FIELD.TOKEN_NAME, FIELD.TOKEN_SYMBOL]],
+    required: ['token_name', 'token_symbol'],
+    tx: TX.CREATE_MOLOCH_TOKEN,
+  },
 };

--- a/src/data/txLegos/contractTX.js
+++ b/src/data/txLegos/contractTX.js
@@ -20,6 +20,7 @@ import { VAULT_TRANSFER_TX } from './transferContractTX';
 import { UBER_MINION_TX } from './uberMinionTX';
 import { WRAPNZAP_BOOST_TX } from './wrapNzapBoostTX';
 import { POSTER_BOOST_TX } from './posterBoostTX';
+import { MOLOCH_TOKEN_FACTORY_TX } from './molochTokenTX';
 
 // TEST LEGOS BEFORE PUSHING TO DEVELOP
 
@@ -65,4 +66,5 @@ export const TX = {
   ...TOKEN_TX,
   ...SWAPR_BOOST_TX,
   ...POSTER_BOOST_TX,
+  ...MOLOCH_TOKEN_FACTORY_TX,
 };

--- a/src/data/txLegos/molochTokenTX.js
+++ b/src/data/txLegos/molochTokenTX.js
@@ -1,0 +1,17 @@
+import { CONTRACTS } from '../contracts';
+
+export const MOLOCH_TOKEN_FACTORY_TX = {
+  CREATE_MOLOCH_TOKEN: {
+    contract: CONTRACTS.MOLOCH_TOKEN_FACTORY,
+    name: 'summonMolochToken',
+    poll: 'boostSubgraph',
+    display: 'Create Moloch Token',
+    errMsg: 'Error creating Moloch Token',
+    successMsg: 'Moloch Token added!',
+    gatherArgs: [
+      '.contextData.daoid',
+      '.values.token_name',
+      '.values.token_symbol',
+    ],
+  },
+};

--- a/src/graphQL/boost-queries.js
+++ b/src/graphQL/boost-queries.js
@@ -101,3 +101,11 @@ export const GET_MINION_BY_NAME = gql`
     }
   }
 `;
+
+export const GET_MOLOCH_TOKEN = gql`
+  query molochTokens($contractAddress: String!) {
+    molochTokens(where: { moloch: $contractAddress }) {
+      id
+    }
+  }
+`;

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -6,16 +6,22 @@ import DaoContractSettings from '../components/daoContractSettings';
 import DaoMetaOverview from '../components/daoMetaOverview';
 import MainViewLayout from '../components/mainViewLayout';
 import TextBox from '../components/TextBox';
-import { fetchTransmutation, getWrapNZap } from '../utils/theGraph';
+import {
+  fetchTransmutation,
+  getWrapNZap,
+  getMolochToken,
+} from '../utils/theGraph';
 
 const Settings = ({ overview, daoMetaData, customTerms }) => {
   const { daochain, daoid } = useParams();
   const [wrapNZap, setWrapNZap] = useState(null);
   const [transmutationContract, setTransmutationContract] = useState(null);
+  const [molochToken, setMolochToken] = useState(null);
 
   useEffect(() => {
     const getWNZ = async () => {
       setWrapNZap(await getWrapNZap(daochain, daoid));
+      setMolochToken(await getMolochToken(daochain, daoid));
       const transmutationRes = await fetchTransmutation({
         chainID: daochain,
         molochAddress: daoid,
@@ -43,6 +49,7 @@ const Settings = ({ overview, daoMetaData, customTerms }) => {
             overview={overview}
             customTerms={customTerms}
             wrapNZap={wrapNZap}
+            molochToken={molochToken}
             transmutationContract={transmutationContract}
           />
           <Flex justify='space-between' mt={6}>

--- a/src/utils/abi.js
+++ b/src/utils/abi.js
@@ -41,6 +41,7 @@ import AMB_MODULE from '../contracts/ambModule.json';
 import AMB from '../contracts/iAmb.json';
 import SF_UUPS_PROXIABLE from '../contracts/uupsProxiable.json';
 import NATIVE_WRAPPER from '../contracts/nativeWrapper.json';
+import MOLOCH_TOKEN_FACTORY from '../contracts/molochTokenFactory.json';
 import { validate } from './validation';
 import { cacheABI, getCachedABI } from './localForage';
 
@@ -77,6 +78,7 @@ export const LOCAL_ABI = Object.freeze({
   AMB_MODULE,
   AMB,
   NATIVE_WRAPPER,
+  MOLOCH_TOKEN_FACTORY,
 });
 
 const getBlockExplorerApiKey = chainID => {

--- a/src/utils/chain.js
+++ b/src/utils/chain.js
@@ -47,7 +47,7 @@ export const supportedChains = {
     escrow_minion: '0xc9f9E7FC92A7D3B2b3554be850fFF462B7b382E7',
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
     poster: '0x000000000000cd17345801aa8147b8d3950260ff',
-
+    moloch_token_factory: '0x94b68149aA9603eeF3fD31A63f6d52AdB4f978D9',
     zodiac_amb_module: {
       amb_bridge_address: {
         '0x64': '0x75Df5AF045d91108662D8080fD1FEFAd6aA0bb59',
@@ -132,6 +132,7 @@ export const supportedChains = {
       staking: '0x732DB307337a5ceA1FD117AF808382FaC0AFAe8a',
     },
     poster: '0x917d84787A266F9D649d519A7Ec8445eA43514D8',
+    moloch_token_factory: '0x12d1a14c06c3b75e541ec7e30a87e13beeda2965',
     zodiac_amb_module: {
       amb_bridge_address: {
         '0x64': '0xc38D4991c951fE8BCE1a12bEef2046eF36b0FA4A',
@@ -190,6 +191,7 @@ export const supportedChains = {
       safe_sign_lib_addr: '0xa25b3579a295be016de5eb5F082b54B12d45F72C',
     },
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
+    moloch_token_factory: '0x2298cc330a4c359aea3583ddd81bacfab53d7da5',
   },
   '0xa': {
     name: 'Optimism Mainnet',
@@ -240,6 +242,7 @@ export const supportedChains = {
     },
     escrow_minion: '', // TODO team will add
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
+    moloch_token_factory: '0xdb0f2d9ef30ffae97474d6db8c1f0e999934737d',
     zodiac_amb_module: {
       amb_bridge_address: {
         '0xa': '', // TODO team will add
@@ -320,6 +323,7 @@ export const supportedChains = {
       version: 'v1',
     },
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
+    moloch_token_factory: '0xF89e2f69FB1351D37b9F82e77bbF10A02cdC5042',
     dao_conditional_helper_addr: '0x55c8F8a71aD01FC707Bbb1A04d2c0Ef246973392',
     zodiac_amb_module: {
       amb_bridge_address: {
@@ -402,6 +406,7 @@ export const supportedChains = {
       version: 'v1',
     },
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
+    moloch_token_factory: '0x651657ffc274f492c8006e847350e12ed1c8491a',
     dao_conditional_helper_addr: '0x8beE9422987ddd6fB57Cd546d184A0a6094DF7A8',
   },
   '0xa4b1': {
@@ -452,6 +457,7 @@ export const supportedChains = {
       version: 'v1',
     },
     disperse_app: '0x692B5A7eCcCad243a07535E8C24B0E7433238C6a',
+    moloch_token_factory: '0x691086c17418589688f0d3031cfc8d9400df8817',
     dao_conditional_helper_addr: '0xF5fb9ce16dbf5B0a7b632Ed5D3F0278E0043B7AE',
   },
   '0xa4ec': {
@@ -502,6 +508,7 @@ export const supportedChains = {
       version: 'v1',
     },
     disperse_app: '0xD152f549545093347A162Dce210e7293f1452150',
+    moloch_token_factory: '',
   },
   // '0x4a': {
   //   name: 'IDChain',

--- a/src/utils/theGraph.js
+++ b/src/utils/theGraph.js
@@ -28,6 +28,7 @@ import {
   GET_TRANSMUTATION,
   GET_WRAP_N_ZAPS,
   GET_MINION_BY_NAME,
+  GET_MOLOCH_TOKEN,
 } from '../graphQL/boost-queries';
 import { MINION_TYPES } from './proposalUtils';
 import { proposalResolver, daoResolver } from './resolvers';
@@ -655,4 +656,18 @@ export const balanceChainQuery = async ({ address, reactSetter }) => {
       console.error(error);
     }
   });
+};
+
+export const getMolochToken = async (daochain, daoid) => {
+  const records = await graphQuery({
+    endpoint: getGraphEndpoint(daochain, 'boosts_graph_url'),
+    query: GET_MOLOCH_TOKEN,
+    variables: {
+      contractAddress: daoid,
+    },
+  });
+  if (records.molochTokens?.length > 0) {
+    return records.molochTokens[0].id;
+  }
+  return null;
 };


### PR DESCRIPTION
## GitHub Issue

Kinda exploratory and need found in RG/MC. When DAO Tooling is popping up that doesn't directly support Moloch shares we can use a Moloch Token wrapper to enable support for DAO shares in those ecosystems.

## Changes

As the issue above outlines this summons a new Moloch Token for the given DAO and provides the address to members. Summoning the Moloch Token requires a Token Name and Token Symbol

<img width="683" alt="Screen Shot 2022-05-10 at 17 02 00" src="https://user-images.githubusercontent.com/1778380/167729312-585f8a91-004e-45a8-a884-7787823ebf8b.png">

Then the address is provided in the settings for easy use.

<img width="850" alt="Screen Shot 2022-05-10 at 17 02 15" src="https://user-images.githubusercontent.com/1778380/167729345-7647dbe3-f753-476a-b5ac-88a8611fcd1b.png">

## Packages Added

none

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs and builds locally
