### PR TITLE
show minion/dao metadata info on members list

### DIFF
--- a/src/components/entityAvatar.jsx
+++ b/src/components/entityAvatar.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+
+import AddressAvatar from './addressAvatar';
+import StaticAvatar from './staticAvatar';
+import { truncateAddr } from '../utils/general';
+import { fetchMetaData } from '../utils/metadata';
+
+const EntityAvatar = React.memo(({ member }) => {
+  const [loading, setLoading] = useState(false);
+  const [memberMeta, setMemberMeta] = useState();
+
+  useEffect(() => {
+    const fetchMeta = async () => {
+      setLoading(true);
+      if (member.isDao) {
+        const [meta] = await fetchMetaData(member.memberAddress);
+        setMemberMeta(meta);
+      }
+      if (member.isSafeMinion) {
+        if (member.isSafeMinion.minions.length === 1) {
+          const [meta] = await fetchMetaData(
+            member.isSafeMinion.minions[0].molochAddress,
+          );
+          setMemberMeta(meta);
+        } else {
+          setMemberMeta(member.isSafeMinion);
+        }
+      }
+      setLoading(false);
+    };
+    if (member.isDao || member.isSafeMinion) {
+      fetchMeta();
+    }
+  }, []);
+
+  return loading ? (
+    <AddressAvatar addr={member.memberAddress} hideCopy />
+  ) : (
+    <StaticAvatar
+      address={member.memberAddress}
+      avatarImg={
+        memberMeta?.avatarImg &&
+        `https://ipfs.infura.io/ipfs/${memberMeta.avatarImg}`
+      }
+      name={memberMeta?.name || `Minion: ${truncateAddr(member.memberAddress)}`}
+      hideCopy
+    />
+  );
+});
+
+export default EntityAvatar;

--- a/src/components/memberCard.jsx
+++ b/src/components/memberCard.jsx
@@ -3,15 +3,15 @@ import { Flex, Box, Badge } from '@chakra-ui/react';
 import { format } from 'date-fns';
 
 import AddressAvatar from './addressAvatar';
+import EntityAvatar from './entityAvatar';
 import useBoost from '../hooks/useBoost';
 import StaticAvatar from './staticAvatar';
 
 const MemberCard = ({ member, selectMember, selectedMember }) => {
   const { isActive } = useBoost();
 
-  const handleSelect = () => {
-    selectMember(member);
-  };
+  const handleSelect = () =>
+    selectMember(prevMember => prevMember?.id !== member.id && member);
 
   return (
     <Flex
@@ -44,11 +44,13 @@ const MemberCard = ({ member, selectMember, selectedMember }) => {
               hideCopy
             />
           ) : (
-            <AddressAvatar
-              addr={member.memberAddress}
-              hideCopy
-              alwaysShowName
-            />
+            <Box>
+              {!member.isDao && !member.isSafeMinion ? (
+                <AddressAvatar addr={member.memberAddress} hideCopy />
+              ) : (
+                <EntityAvatar member={member} />
+              )}
+            </Box>
           )}
           {member.jailed ? (
             <Badge variant='solid' colorScheme='red' mr={5} height='100%'>

--- a/src/components/memberInfoGuts.jsx
+++ b/src/components/memberInfoGuts.jsx
@@ -11,10 +11,51 @@ const MemberInfoGuts = ({ member, showMenu, hideCopy }) => {
     <>
       {member && (
         <>
-          <Flex justify='space-between'>
-            <AddressAvatar addr={member.memberAddress} hideCopy={hideCopy} />
-            {showMenu ? <ProfileMenu member={member} /> : null}
-          </Flex>
+          {member.isDao || member.isSafeMinion ? (
+            <Flex justify='space-between'>
+              <Flex direction='column'>
+                <TextBox size='sm' mb={2}>
+                  DAO
+                </TextBox>
+                {member.isDao ? (
+                  <AddressAvatar
+                    addr={member.memberAddress}
+                    hideCopy={hideCopy}
+                  />
+                ) : (
+                  <>
+                    {member.isSafeMinion.minions.map(minion => (
+                      <Box
+                        key={minion.minionAddress}
+                        mb={member.isSafeMinion.minions.length > 1 ? 2 : 0}
+                      >
+                        <AddressAvatar
+                          addr={minion.molochAddress}
+                          hideCopy={hideCopy}
+                        />
+                      </Box>
+                    ))}
+                  </>
+                )}
+              </Flex>
+              {member.isSafeMinion && (
+                <Flex direction='column'>
+                  <TextBox size='sm' mb={2}>
+                    Minion
+                  </TextBox>
+                  <AddressAvatar
+                    addr={member.memberAddress}
+                    hideCopy={hideCopy}
+                  />
+                </Flex>
+              )}
+            </Flex>
+          ) : (
+            <Flex justify='space-between'>
+              <AddressAvatar addr={member.memberAddress} hideCopy={hideCopy} />
+              {showMenu ? <ProfileMenu member={member} /> : null}
+            </Flex>
+          )}
           <Flex w='100%' justify='space-between' mt={6}>
             <Box w={['100%']}>
               <TextBox size='xs'>Shares</TextBox>

--- a/src/graphQL/member-queries.js
+++ b/src/graphQL/member-queries.js
@@ -100,6 +100,16 @@ export const MEMBERS_LIST = gql`
       memberAddress
       exists
       createdAt
+      isDao {
+        id
+      }
+      isSafeMinion {
+        id
+        minions {
+          minionAddress
+          molochAddress
+        }
+      }
       moloch {
         id
         totalShares


### PR DESCRIPTION
## GitHub Issue

No related issue. 

## Dependencies

https://github.com/HausDAO/daohaus-supergraph/pull/65 is required to be merged & deployed first

## Changes

Identify dao members that are daos/minions. For example

* Uberhaus
![image](https://user-images.githubusercontent.com/926341/167765623-bd8b0d38-0913-4766-ba94-d560765ea4fc.png)

* Wargames DAO

![image](https://user-images.githubusercontent.com/926341/167765693-0fc8928c-5483-4e5d-8492-2d90dee87383.png)

## Packages Added

No new packages

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
