### PR TITLE
tweak polygon safe URL

### DIFF
--- a/src/utils/chain.js
+++ b/src/utils/chain.js
@@ -349,6 +349,7 @@ export const supportedChains = {
   '0x89': {
     name: 'Polygon',
     short_name: 'polygon',
+    shortNamePrefix: 'matic',
     nativeCurrency: 'MATIC',
     network: 'matic',
     networkAlt: 'polygon',


### PR DESCRIPTION
## GitHub Issue

Fixes #1804 

## Changes

Add `shortNamePrefix` for Polygon to support the specific URL

## Packages Added

nada

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs and builds locally
