### PR TITLE
adding reverse resolver fetch when graph fails to retreive ens name

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "crypto-browserify": "^3.12.0",
     "date-fns": "^2.16.1",
     "deep-eql": "^4.0.0",
+    "eth-ens-namehash": "^2.0.8",
     "eth-sig-util": "3.0.1",
     "ethereum-blockies-base64": "^1.0.2",
     "ethereumjs-util": "^7.1.0",

--- a/src/utils/ens.js
+++ b/src/utils/ens.js
@@ -1,10 +1,12 @@
 import { gql } from 'apollo-boost';
-import { ethers } from 'ethers';
+import { ethers, Contract } from 'ethers';
 import { graphQuery } from './apollo';
 import { chainByID } from './chain';
 
 const ensClient =
   'https://api.thegraph.com/subgraphs/name/ezynda3/ens-subgraph';
+
+const REVERSE_RESOLVER_ADDRESS = '0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C';
 
 const REVERSE_RESOLVER_QUERY = gql`
   query reverseRegistrations($user: String!) {
@@ -15,6 +17,28 @@ const REVERSE_RESOLVER_QUERY = gql`
   }
 `;
 
+const ensReverseRecordRequest = async address => {
+  const provider = ethers.getDefaultProvider(chainByID('0x1').rpc_url);
+  const abi = [
+    {
+      inputs: [
+        { internalType: 'address[]', name: 'addresses', type: 'address[]' },
+      ],
+      name: 'getNames',
+      outputs: [{ internalType: 'string[]', name: 'r', type: 'string[]' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ];
+
+  try {
+    const contract = new Contract(REVERSE_RESOLVER_ADDRESS, abi, provider);
+    return await contract.getNames([address]);
+  } catch (e) {
+    return Promise.reject(e);
+  }
+};
+
 const fetchENS = async address => {
   try {
     const result = await graphQuery({
@@ -24,10 +48,17 @@ const fetchENS = async address => {
         user: address.toLowerCase(),
       },
     });
+
     if (result.reverseRegistrations.length) {
       // look into dealing with multiple. get most recent
       return result.reverseRegistrations.sort((a, b) => b.block - a.block)[0]
         .name;
+    }
+
+    const recordRequest = await ensReverseRecordRequest(address.toLowerCase());
+
+    if (recordRequest.length) {
+      return recordRequest[0];
     }
 
     return false;

--- a/src/utils/ens.js
+++ b/src/utils/ens.js
@@ -33,10 +33,9 @@ const ensReverseRecordRequest = async address => {
   ];
   try {
     const contract = new Contract(REVERSE_RESOLVER_ADDRESS, abi, provider);
-    const names = await contract.getNames([address]);
-    return normalize(names[0]);
+    return await contract.getNames([address]);
   } catch (e) {
-    return null;
+    return Promise.reject(e);
   }
 };
 
@@ -56,7 +55,10 @@ const fetchENS = async address => {
     }
     const recordRequest = await ensReverseRecordRequest(address.toLowerCase());
     if (recordRequest.length) {
-      return recordRequest[0];
+      const name = recordRequest[0];
+      if (normalize(name) === name) {
+        return name;
+      }
     }
     return false;
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10566,7 +10566,7 @@ eth-block-tracker@^4.4.2:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-ens-namehash@2.0.8:
+eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz#229ac46eca86d52e0c991e7cb2aef83ff0f68bcf"
   integrity sha1-IprEbsqG1S4MmR58sq74P/D2i88=


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-app/issues/1731

## Changes

- [X] added a backup contract call to the reverse records to ensure that eth name is retrieved.

This solution works, I am not sure if it is the right solution though. I spent some time in the ens subgraph trying to grab this information but I was not able to. It turns out @scottrepreneur opened a pr for this on there subgraph a while ago
[pr link](https://github.com/ensdomains/ens-subgraph/pull/26)
[issue link](https://github.com/ensdomains/ens-subgraph/issues/25)

I can pick that subgraph pr up and we can attempt to fix it that way depending on what we want to do here

## Packages Added

[eth-ens-namehash](https://github.com/danfinlay/eth-ens-namehash) - adding normalize check as [recommended by ens docs](
https://docs.ens.domains/dapp-developer-guide/resolving-names#reverse-resolution)

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally

## Details

you can see the call return the right address in this console log:

1) graph is called which returns `null` for the `reverseRegistations` (ie 0 length)
2) contract is called which correctly identifies the ens name (hardcoded griffs address in the actual console.log on my local environment)

![Screen Shot 2022-05-20 at 3 51 59 PM](https://user-images.githubusercontent.com/5998100/169617339-6b90929c-cfd2-4ff2-9240-171054a72ba6.png)

![Screen Shot 2022-05-20 at 3 54 27 PM](https://user-images.githubusercontent.com/5998100/169617562-0451eeb7-f25a-44a0-a13f-86be2a1093cb.png)

