### PR TITLE
Fix/spam filter settings

### DIFF
--- a/src/data/boostSettings.js
+++ b/src/data/boostSettings.js
@@ -1,4 +1,6 @@
+import { merge } from 'lodash';
 import { FIELD, INFO_TEXT } from './fields';
+import { FORM } from './formLegos/forms';
 import { COMMON_STEPS, CONTENT } from './boosts';
 
 const SETTING_STEPS = {
@@ -6,35 +8,24 @@ const SETTING_STEPS = {
     STEP1: {
       type: 'boostMetaForm',
       form: {
-        id: 'SPAM_FILTER',
-        title: 'Minimum Tribute',
-        required: ['paymentRequested'],
+        ...FORM.SPAM_FILTER,
         fields: [
-          [
-            {
-              ...FIELD.PAYMENT_REQUEST,
-              label: 'Amount in Deposit Token',
-              info: INFO_TEXT.SPAM_FILTER_AMOUNT,
-              hideMax: true,
-            },
-            {
-              ...FIELD.BASIC_SWITCH,
-              label: 'Spam filter active?',
-              name: 'active',
-            },
-            {
-              ...FIELD.PAYMENT_REQUEST,
-              label: '<A></A>mount in Deposit Token',
-              info: INFO_TEXT.SPAM_FILTER_AMOUNT,
-              depositTokenOnly: true,
-              hideMax: true,
-            },
-            {
-              ...FIELD.BASIC_SWITCH,
-              name: 'membersOnly',
-              label: 'Hide new proposal button from non members?',
-            },
-          ],
+          merge(
+            [
+              {
+                ...FIELD.PAYMENT_REQUEST,
+                label: 'Amount in Deposit Token',
+                info: INFO_TEXT.SPAM_FILTER_AMOUNT,
+                hideMax: true,
+              },
+              {
+                ...FIELD.BASIC_SWITCH,
+                label: 'Spam filter active?',
+                name: 'active',
+              },
+            ],
+            FORM.SPAM_FILTER.fields,
+          ),
         ],
       },
       next: 'STEP2',

--- a/src/data/boostSettings.js
+++ b/src/data/boostSettings.js
@@ -1,5 +1,4 @@
 import { FIELD, INFO_TEXT } from './fields';
-import { FORM } from './formLegos/forms';
 import { COMMON_STEPS, CONTENT } from './boosts';
 
 const SETTING_STEPS = {
@@ -7,7 +6,9 @@ const SETTING_STEPS = {
     STEP1: {
       type: 'boostMetaForm',
       form: {
-        ...FORM.SPAM_FILTER,
+        id: 'SPAM_FILTER',
+        title: 'Minimum Tribute',
+        required: ['paymentRequested'],
         fields: [
           [
             {
@@ -20,6 +21,18 @@ const SETTING_STEPS = {
               ...FIELD.BASIC_SWITCH,
               label: 'Spam filter active?',
               name: 'active',
+            },
+            {
+              ...FIELD.PAYMENT_REQUEST,
+              label: '<A></A>mount in Deposit Token',
+              info: INFO_TEXT.SPAM_FILTER_AMOUNT,
+              depositTokenOnly: true,
+              hideMax: true,
+            },
+            {
+              ...FIELD.BASIC_SWITCH,
+              name: 'membersOnly',
+              label: 'Hide new proposal button from non members?',
             },
           ],
         ],


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-app/issues/1641

## Changes

use lodash's `merge`  to fix spread operation overwriting `FORM.SPAM_FILTER`. I [originally duplicated the settings from `FORM.SPAM_FILTER`](https://github.com/HausDAO/daohaus-app/commit/a8effcf0da9e775a2f5720e80fe46fc002464e56), but decided to use `merge` to maintain single config construction in case `FORM.SPAM_FILTER` changes at some point.

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally

# Details

<img width="698" alt="Screen Shot 2022-05-21 at 3 33 16 PM" src="https://user-images.githubusercontent.com/5998100/169669726-58615f64-47b2-4eb3-a4a8-6d2e8fe79d2f.png">

