### PR TITLE
adding regex config for Minion Proposals and helper for fixing Minion

### DIFF
--- a/src/utils/proposalContent.js
+++ b/src/utils/proposalContent.js
@@ -46,7 +46,7 @@ export const defaultFilterOptions = {
     },
     {
       name: 'Minion Proposals',
-      value: 'Minion Proposal',
+      value: /Minion Proposal/i,
       type: 'proposalType',
     },
   ],

--- a/src/utils/proposalContent.js
+++ b/src/utils/proposalContent.js
@@ -46,7 +46,7 @@ export const defaultFilterOptions = {
     },
     {
       name: 'Minion Proposals',
-      value: /Minion Proposal/i,
+      value: /Minion/i,
       type: 'proposalType',
     },
   ],

--- a/src/utils/proposalUtils.jsx
+++ b/src/utils/proposalUtils.jsx
@@ -611,6 +611,12 @@ export const handleListFilter = (proposals, filter, daoMember, daoid) => {
     );
   }
 
+  if (filter.value instanceof RegExp) {
+    return updatedProposals.filter(proposal =>
+      filter.value.test(proposal[filter.type]),
+    );
+  }
+
   return updatedProposals.filter(
     proposal => proposal[filter.type] === filter.value,
   );


### PR DESCRIPTION
Proposal filter

## GitHub Issue

https://github.com/HausDAO/daohaus-app/issues/1781

## Changes

adding config to Minion Proposal so they are picked up in the filter.

This bug is caused by the value of the Proposal config `Minion Proposal` does not match all of the different Minion `ProposalTypes` (see screen shot below).

I got a little clever with this one and used a Regex of `/Minion Proposal/i` to match all the scenarios listed in `ProposalType`, and added a filter helper for when the config is a Regex. Not sure if this is too clever and should be adjusted to hardcoding every [Minion proposal type in `proposalContent.js`](https://github.com/brossetti1/daohaus-app/blob/b77d7044619704316d528af0841ee74acdc8c095/src/utils/proposalContent.js#L49) - anyways, let me know

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally

## Details

![Screen Shot 2022-05-22 at 2 37 14 PM](https://user-images.githubusercontent.com/5998100/169715072-80264087-18cd-46ab-b593-81e959ca2a76.png)
![Screen Shot 2022-05-22 at 2 43 35 PM](https://user-images.githubusercontent.com/5998100/169715074-d00a1ca5-ea33-4f7a-8336-4ff4a3f1e31e.png)
