### PR TITLE
Feature/lit integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "graphql": "^15.4.0",
     "https-browserify": "^1.0.0",
     "human-format": "^0.11.0",
+    "lit-js-sdk": "^1.1.182",
     "localforage": "^1.10.0",
     "os-browserify": "^0.3.0",
     "polished": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lit-js-sdk": "^1.1.182",
     "localforage": "^1.10.0",
     "os-browserify": "^0.3.0",
+    "path": "^0.12.7",
     "polished": "^4.0.5",
     "process": "^0.11.10",
     "rc-pagination": "^3.1.3",

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -1,39 +1,69 @@
-import { Box, Flex, HStack, Link, Stack } from '@chakra-ui/react';
+import {
+  Button,
+  Center,
+  Flex,
+  HStack,
+  Link,
+  Stack,
+  VStack,
+} from '@chakra-ui/react';
 import { format } from 'date-fns';
 import React from 'react';
-import { getAssetType } from '../utils/litProtocol';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
+import { getAssetType, LIT_API_HOST } from '../utils/litProtocol';
 import ContentBox from './ContentBox';
 import TextBox from './TextBox';
+import { ParaMd } from './typography';
 
-const GoogleLitCard = ({ googleDoc }) => {
+const GoogleLitCard = ({
+  googleDoc,
+  getLinkFromShare,
+  handleDeleteShare,
+  daoMetaData,
+}) => {
   // https://oauth-app.litgateway.com/google/l/5e5ec2da-578c-43b5-ba76-c326526f8621
   return (
-    <ContentBox
-      as={Link}
-      href={`https://oauth-app.litgateway.com/google/l/${googleDoc.id}`}
-      w='60%'
-      isExternal
-    >
+    <ContentBox w='60%'>
       <Stack spacing={4}>
         <TextBox size='lg' color='whiteAlpha.900' maxW='80%'>
           {googleDoc?.name}
         </TextBox>
-        <Flex as={HStack} spacing={2} align='center'>
-          <TextBox>Asset Type:</TextBox>
-          <TextBox variant='value' size='sm'>
-            {getAssetType(googleDoc?.assetType)}
-          </TextBox>
+        <Flex as={HStack} alignItems='center'>
+          <Flex as={VStack} spacing={4} alignItems='start'>
+            <Flex as={HStack} spacing={2} align='left'>
+              <TextBox>Asset Type:</TextBox>
+              <TextBox variant='value' size='sm'>
+                {getAssetType(googleDoc?.assetType)}
+              </TextBox>
+            </Flex>
+            <Flex as={HStack} spacing={2} align='left'>
+              <TextBox>Role:</TextBox>
+              <TextBox variant='value'>{googleDoc?.role}</TextBox>
+            </Flex>
+            <Flex as={HStack} spacing={2} align='left'>
+              <TextBox>Date Created:</TextBox>
+              <TextBox variant='value'>
+                {format(new Date(googleDoc.createdAt), 'MMMM d, yyyy p')}
+              </TextBox>
+            </Flex>
+          </Flex>
         </Flex>
-        <Flex as={HStack} spacing={2} align='center'>
-          <TextBox>Role:</TextBox>
-          <TextBox variant='value'>{googleDoc?.role}</TextBox>
-        </Flex>
-        <Flex as={HStack} spacing={2} align='center'>
-          <TextBox>Date Created:</TextBox>
-          <TextBox variant='value'>
-            {format(new Date(googleDoc.createdAt), 'MMMM d, yyyy p')}
-          </TextBox>
+        <Flex>
+          <Center mr={10}>
+            <Link to={`${LIT_API_HOST}/google/l/${googleDoc.id}`}>
+              <ParaMd>VIEW</ParaMd>
+            </Link>
+          </Center>
+          <CopyToClipboard
+            text={`${LIT_API_HOST}/google/l/${googleDoc.id}`}
+            onCopy={getLinkFromShare}
+          >
+            <Button>SHARE LINK</Button>
+          </CopyToClipboard>
+          <Button onClick={() => handleDeleteShare(googleDoc)} ml={10}>
+            <ParaMd>DELETE</ParaMd>
+          </Button>
         </Flex>
       </Stack>
     </ContentBox>

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -6,19 +6,6 @@ import { getAssetType } from '../utils/litProtocol';
 import ContentBox from './ContentBox';
 import TextBox from './TextBox';
 
-// accessControlConditions: "[{\"contractAddress\":\"0x33505b8dba67eb39fd65e3270cefacbe5b9da4cd\",\"standardContractType\":\"MolochDAOv2.1\",\"chain\":\"ethereum\",\"method\":\"members\",\"parameters\":[\":userAddress\"],\"returnValueTest\":{\"comparator\":\"=\",\"value\":\"true\"}}]"
-// assetIdOnService: "1wncxq6LEzvAHfGXVcOvNeHU0t-0IcE1ERSeKTApvsLo"
-// assetType: "application/vnd.google-apps.spreadsheet"
-// connectedServiceId: "c49459b7-b966-4f29-82b6-56bf2ff0e577"
-// createdAt: new Date("2022-06-07T20:33:30.392Z")
-// daoAddress: null
-// id: "a6062ff0-a351-44b3-bf17-c6c7b20643cb"
-// name: "ETH NYC - June 23th - June 28th"
-// role: "reader"
-// source: null
-// updatedAt: "2022-06-07T20:33:30.392Z"
-// userId: "0xb0cffe0260bf4ea7b59915fbea17273a8b9209f6"
-
 const GoogleLitCard = ({ googleDoc }) => {
   // https://oauth-app.litgateway.com/google/l/5e5ec2da-578c-43b5-ba76-c326526f8621
   return (

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -1,0 +1,69 @@
+import { Box, Flex, HStack, Link, Stack } from '@chakra-ui/react';
+import { format } from 'date-fns';
+import React from 'react';
+import { getAssetType } from '../utils/litProtocol';
+
+import ContentBox from './ContentBox';
+import TextBox from './TextBox';
+
+// accessControlConditions: "[{\"contractAddress\":\"0x33505b8dba67eb39fd65e3270cefacbe5b9da4cd\",\"standardContractType\":\"MolochDAOv2.1\",\"chain\":\"ethereum\",\"method\":\"members\",\"parameters\":[\":userAddress\"],\"returnValueTest\":{\"comparator\":\"=\",\"value\":\"true\"}}]"
+// assetIdOnService: "1wncxq6LEzvAHfGXVcOvNeHU0t-0IcE1ERSeKTApvsLo"
+// assetType: "application/vnd.google-apps.spreadsheet"
+// connectedServiceId: "c49459b7-b966-4f29-82b6-56bf2ff0e577"
+// createdAt: "2022-06-07T20:33:30.392Z"
+// daoAddress: null
+// id: "a6062ff0-a351-44b3-bf17-c6c7b20643cb"
+// name: "ETH NYC - June 23th - June 28th"
+// role: "reader"
+// source: null
+// updatedAt: "2022-06-07T20:33:30.392Z"
+// userId: "0xb0cffe0260bf4ea7b59915fbea17273a8b9209f6"
+
+// accessControlConditions: "[{\"contractAddress\":\"0x33505b8dba67eb39fd65e3270cefacbe5b9da4cd\",\"standardContractType\":\"MolochDAOv2.1\",\"chain\":\"ethereum\",\"method\":\"members\",\"parameters\":[\":userAddress\"],\"returnValueTest\":{\"comparator\":\"=\",\"value\":\"true\"}}]"
+// assetIdOnService: "1wncxq6LEzvAHfGXVcOvNeHU0t-0IcE1ERSeKTApvsLo"
+// assetType: "application/vnd.google-apps.spreadsheet"
+// connectedServiceId: "c49459b7-b966-4f29-82b6-56bf2ff0e577"
+// createdAt: "2022-06-07T20:46:16.147Z"
+// daoAddress: null
+// id: "5e5ec2da-578c-43b5-ba76-c326526f8621"
+// name: "ETH NYC - June 23th - June 28th"
+// role: "reader"
+// source: null
+// updatedAt: "2022-06-07T20:46:16.147Z"
+// userId: "0xb0cffe0260bf4ea7b59915fbea17273a8b9209f6"
+
+const GoogleLitCard = ({ googleDoc }) => {
+  // https://oauth-app.litgateway.com/google/l/5e5ec2da-578c-43b5-ba76-c326526f8621
+  return (
+    <ContentBox
+      as={Link}
+      href={`https://oauth-app.litgateway.com/google/l/${googleDoc.id}`}
+      w='60%'
+      isExternal
+    >
+      <Stack spacing={4}>
+        <TextBox size='lg' color='whiteAlpha.900' maxW='80%'>
+          {googleDoc?.name}
+        </TextBox>
+        <Flex as={HStack} spacing={2} align='center'>
+          <TextBox>Asset Type:</TextBox>
+          <TextBox variant='value' size='sm'>
+            {getAssetType(googleDoc?.assetType)}
+          </TextBox>
+        </Flex>
+        <Flex as={HStack} spacing={2} align='center'>
+          <TextBox>Role:</TextBox>
+          <TextBox variant='value'>{googleDoc?.role}</TextBox>
+        </Flex>
+        {/* <Flex as={HStack} spacing={2} align='center'>
+          <TextBox>Date Created:</TextBox>
+          <TextBox variant='value'>
+            {format(googleDoc?.createdAt, 'MMMM d, yyyy p')}
+          </TextBox>
+        </Flex> */}
+      </Stack>
+    </ContentBox>
+  );
+};
+
+export default GoogleLitCard;

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -16,12 +16,7 @@ import ContentBox from './ContentBox';
 import TextBox from './TextBox';
 import { ParaMd } from './typography';
 
-const GoogleLitCard = ({
-  googleDoc,
-  getLinkFromShare,
-  handleDeleteShare,
-  daoMetaData,
-}) => {
+const GoogleLitCard = ({ googleDoc, getLinkFromShare, handleDeleteShare }) => {
   // https://oauth-app.litgateway.com/google/l/5e5ec2da-578c-43b5-ba76-c326526f8621
   return (
     <ContentBox w='60%'>

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -54,10 +54,10 @@ const GoogleLitCard = ({ googleDoc, getLinkFromShare, handleDeleteShare }) => {
             text={`${LIT_API_HOST}/google/l/${googleDoc.id}`}
             onCopy={getLinkFromShare}
           >
-            <Button>SHARE LINK</Button>
+            <Button>COPY LINK</Button>
           </CopyToClipboard>
           <Button onClick={() => handleDeleteShare(googleDoc)} ml={10}>
-            <ParaMd>DELETE</ParaMd>
+            <ParaMd>UNSHARE</ParaMd>
           </Button>
         </Flex>
       </Stack>

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -17,7 +17,6 @@ import TextBox from './TextBox';
 import { ParaMd } from './typography';
 
 const GoogleLitCard = ({ googleDoc, getLinkFromShare, handleDeleteShare }) => {
-  // https://oauth-app.litgateway.com/google/l/5e5ec2da-578c-43b5-ba76-c326526f8621
   return (
     <ContentBox w='60%'>
       <Stack spacing={4}>

--- a/src/components/GoogleLitCard.jsx
+++ b/src/components/GoogleLitCard.jsx
@@ -10,26 +10,13 @@ import TextBox from './TextBox';
 // assetIdOnService: "1wncxq6LEzvAHfGXVcOvNeHU0t-0IcE1ERSeKTApvsLo"
 // assetType: "application/vnd.google-apps.spreadsheet"
 // connectedServiceId: "c49459b7-b966-4f29-82b6-56bf2ff0e577"
-// createdAt: "2022-06-07T20:33:30.392Z"
+// createdAt: new Date("2022-06-07T20:33:30.392Z")
 // daoAddress: null
 // id: "a6062ff0-a351-44b3-bf17-c6c7b20643cb"
 // name: "ETH NYC - June 23th - June 28th"
 // role: "reader"
 // source: null
 // updatedAt: "2022-06-07T20:33:30.392Z"
-// userId: "0xb0cffe0260bf4ea7b59915fbea17273a8b9209f6"
-
-// accessControlConditions: "[{\"contractAddress\":\"0x33505b8dba67eb39fd65e3270cefacbe5b9da4cd\",\"standardContractType\":\"MolochDAOv2.1\",\"chain\":\"ethereum\",\"method\":\"members\",\"parameters\":[\":userAddress\"],\"returnValueTest\":{\"comparator\":\"=\",\"value\":\"true\"}}]"
-// assetIdOnService: "1wncxq6LEzvAHfGXVcOvNeHU0t-0IcE1ERSeKTApvsLo"
-// assetType: "application/vnd.google-apps.spreadsheet"
-// connectedServiceId: "c49459b7-b966-4f29-82b6-56bf2ff0e577"
-// createdAt: "2022-06-07T20:46:16.147Z"
-// daoAddress: null
-// id: "5e5ec2da-578c-43b5-ba76-c326526f8621"
-// name: "ETH NYC - June 23th - June 28th"
-// role: "reader"
-// source: null
-// updatedAt: "2022-06-07T20:46:16.147Z"
 // userId: "0xb0cffe0260bf4ea7b59915fbea17273a8b9209f6"
 
 const GoogleLitCard = ({ googleDoc }) => {
@@ -55,12 +42,12 @@ const GoogleLitCard = ({ googleDoc }) => {
           <TextBox>Role:</TextBox>
           <TextBox variant='value'>{googleDoc?.role}</TextBox>
         </Flex>
-        {/* <Flex as={HStack} spacing={2} align='center'>
+        <Flex as={HStack} spacing={2} align='center'>
           <TextBox>Date Created:</TextBox>
           <TextBox variant='value'>
-            {format(googleDoc?.createdAt, 'MMMM d, yyyy p')}
+            {format(new Date(googleDoc.createdAt), 'MMMM d, yyyy p')}
           </TextBox>
-        </Flex> */}
+        </Flex>
       </Stack>
     </ContentBox>
   );

--- a/src/data/boosts.js
+++ b/src/data/boosts.js
@@ -711,7 +711,7 @@ export const BOOSTS = {
     cost: 'free',
     settings: {
       type: 'internalLink',
-      appendToDaoPath: 'boost/lit/settings',
+      appendToDaoPath: 'boost/lit-protocol/google',
     },
   },
 };

--- a/src/data/boosts.js
+++ b/src/data/boosts.js
@@ -295,6 +295,11 @@ export const CONTENT = {
       { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
     ],
   },
+  /*
+ TODO commenting out until we hear back from Lit on remaining integration items.
+  see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897
+  for more details.
+
   GOOGLE_LIT: {
     title: 'Lit Protocol Google Drive',
     description: 'Share google documents with the dao',
@@ -308,6 +313,7 @@ export const CONTENT = {
       { href: 'https://github.com/LIT-Protocol', label: 'Lit Github' },
     ],
   },
+  */
 };
 
 export const COMMON_STEPS = {
@@ -692,28 +698,34 @@ export const BOOSTS = {
     cost: 'free',
     settings: 'none',
   },
-  GOOGLE_LIT: {
-    id: 'GOOGLE_LIT',
-    boostContent: CONTENT.GOOGLE_LIT,
-    steps: STEPS.BASIC_BOOST,
-    categories: ['community'],
-    networks: {
-      // LIT_NETWORKS - https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/lib/constants.js#L30
-      '0x1': true,
-      '0x4': true,
-      '0x2a': true,
-      '0xa': true,
-      '0x64': true,
-      '0x89': true,
-      '0xa4b1': true,
-      '0xa4ec': true,
+  /*
+    TODO commenting out until we hear back from Lit on remaining integration items.
+    see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897
+    for more details.
+
+    GOOGLE_LIT: {
+      id: 'GOOGLE_LIT',
+      boostContent: CONTENT.GOOGLE_LIT,
+      steps: STEPS.BASIC_BOOST,
+      categories: ['community'],
+      networks: {
+        // LIT_NETWORKS - https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/lib/constants.js#L30
+        '0x1': true,
+        '0x4': true,
+        '0x2a': true,
+        '0xa': true,
+        '0x64': true,
+        '0x89': true,
+        '0xa4b1': true,
+        '0xa4ec': true,
+      },
+      cost: 'free',
+      settings: {
+        type: 'internalLink',
+        appendToDaoPath: 'boost/lit-protocol/google',
+      },
     },
-    cost: 'free',
-    settings: {
-      type: 'internalLink',
-      appendToDaoPath: 'boost/lit-protocol/google',
-    },
-  },
+  */
 };
 
 export const allBoosts = {

--- a/src/data/boosts.js
+++ b/src/data/boosts.js
@@ -295,6 +295,19 @@ export const CONTENT = {
       { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
     ],
   },
+  GOOGLE_LIT: {
+    title: 'Lit Google',
+    description: 'Share google documents with the dao',
+    publisher: PUBLISHERS.DAOHAUS,
+    version: '0.1',
+    pars: [
+      'This boost allows daos to share google docs with other users in the dao',
+    ],
+    externalLinks: [
+      { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
+      { href: 'https://github.com/LIT-Protocol', label: 'Lit Github' },
+    ],
+  },
 };
 
 export const COMMON_STEPS = {
@@ -678,6 +691,15 @@ export const BOOSTS = {
     networks: 'all',
     cost: 'free',
     settings: 'none',
+  },
+  GOOGLE_LIT: {
+    id: 'GOOGLE_LIT',
+    boostContent: CONTENT.GOOGLE_LIT,
+    steps: STEPS.BASIC_BOOST,
+    // playlist: BOOST_PLAYLISTS.GOOGLE_LIT,
+    categories: ['community'],
+    networks: { '0x64': true, '0x1': true, '0x4': true }, // TODO: Add more
+    cost: 'free',
   },
 };
 

--- a/src/data/boosts.js
+++ b/src/data/boosts.js
@@ -296,7 +296,7 @@ export const CONTENT = {
     ],
   },
   GOOGLE_LIT: {
-    title: 'Lit Google',
+    title: 'Lit Protocol Google Drive',
     description: 'Share google documents with the dao',
     publisher: PUBLISHERS.DAOHAUS,
     version: '0.1',
@@ -696,10 +696,23 @@ export const BOOSTS = {
     id: 'GOOGLE_LIT',
     boostContent: CONTENT.GOOGLE_LIT,
     steps: STEPS.BASIC_BOOST,
-    // playlist: BOOST_PLAYLISTS.GOOGLE_LIT,
     categories: ['community'],
-    networks: { '0x64': true, '0x1': true, '0x4': true }, // TODO: Add more
+    networks: {
+      // LIT_NETWORKS - https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/lib/constants.js#L30
+      '0x1': true,
+      '0x4': true,
+      '0x2a': true,
+      '0xa': true,
+      '0x64': true,
+      '0x89': true,
+      '0xa4b1': true,
+      '0xa4ec': true,
+    },
     cost: 'free',
+    settings: {
+      type: 'internalLink',
+      appendToDaoPath: 'boost/lit/settings',
+    },
   },
 };
 

--- a/src/data/boosts.js
+++ b/src/data/boosts.js
@@ -5,6 +5,27 @@ import { FORM } from './formLegos/forms';
 import { MINIONS } from './minions';
 import { PUBLISHERS } from './publishers';
 
+let litContent = {};
+if (process.env.REACT_APP_DEV) {
+  /*
+    TODO adding a flag to activate the LIT integration until the Lit team gets back to us
+    see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897 for more details.
+  */
+  litContent['GOOGLE_LIT'] = {
+    title: 'Lit Protocol Google Drive',
+    description: 'Share google documents with the dao',
+    publisher: PUBLISHERS.DAOHAUS,
+    version: '0.1',
+    pars: [
+      'This boost allows daos to share google docs with other users in the dao',
+    ],
+    externalLinks: [
+      { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
+      { href: 'https://github.com/LIT-Protocol', label: 'Lit Github' },
+    ],
+  };
+}
+
 export const CONTENT = {
   DEV_SUITE: {
     title: 'DEV Suite',
@@ -295,25 +316,7 @@ export const CONTENT = {
       { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
     ],
   },
-  /*
- TODO commenting out until we hear back from Lit on remaining integration items.
-  see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897
-  for more details.
-
-  GOOGLE_LIT: {
-    title: 'Lit Protocol Google Drive',
-    description: 'Share google documents with the dao',
-    publisher: PUBLISHERS.DAOHAUS,
-    version: '0.1',
-    pars: [
-      'This boost allows daos to share google docs with other users in the dao',
-    ],
-    externalLinks: [
-      { href: 'https://discord.gg/daohaus', label: 'Boost Support' },
-      { href: 'https://github.com/LIT-Protocol', label: 'Lit Github' },
-    ],
-  },
-  */
+  ...litContent,
 };
 
 export const COMMON_STEPS = {
@@ -455,6 +458,36 @@ export const STEPS = {
     STEP2: { ...COMMON_STEPS.SIGNER, daoRefetch: true },
   },
 };
+
+let litBoost = {};
+if (process.env.REACT_APP_DEV) {
+  /*
+    TODO adding a flag to activate the LIT integration until the Lit team gets back to us
+    see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897 for more details.
+  */
+  litBoost['GOOGLE_LIT'] = {
+    id: 'GOOGLE_LIT',
+    boostContent: CONTENT.GOOGLE_LIT,
+    steps: STEPS.BASIC_BOOST,
+    categories: ['community'],
+    networks: {
+      // LIT_NETWORKS - https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/lib/constants.js#L30
+      '0x1': true,
+      '0x4': true,
+      '0x2a': true,
+      '0xa': true,
+      '0x64': true,
+      '0x89': true,
+      '0xa4b1': true,
+      '0xa4ec': true,
+    },
+    cost: 'free',
+    settings: {
+      type: 'internalLink',
+      appendToDaoPath: 'boost/lit-protocol/google',
+    },
+  };
+}
 
 export const BOOSTS = {
   OLD_DEV_SUITE: {
@@ -698,34 +731,7 @@ export const BOOSTS = {
     cost: 'free',
     settings: 'none',
   },
-  /*
-    TODO commenting out until we hear back from Lit on remaining integration items.
-    see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897
-    for more details.
-
-    GOOGLE_LIT: {
-      id: 'GOOGLE_LIT',
-      boostContent: CONTENT.GOOGLE_LIT,
-      steps: STEPS.BASIC_BOOST,
-      categories: ['community'],
-      networks: {
-        // LIT_NETWORKS - https://github.com/LIT-Protocol/lit-js-sdk/blob/main/src/lib/constants.js#L30
-        '0x1': true,
-        '0x4': true,
-        '0x2a': true,
-        '0xa': true,
-        '0x64': true,
-        '0x89': true,
-        '0xa4b1': true,
-        '0xa4ec': true,
-      },
-      cost: 'free',
-      settings: {
-        type: 'internalLink',
-        appendToDaoPath: 'boost/lit-protocol/google',
-      },
-    },
-  */
+  ...litBoost,
 };
 
 export const allBoosts = {

--- a/src/data/playlists.js
+++ b/src/data/playlists.js
@@ -62,11 +62,11 @@ export const BOOST_PLAYLISTS = {
     id: 'poster',
     forms: ['RATIFY_DAO_DOC', 'POST_IPFS_MD', 'POST_MD'],
   },
-  GOOGLE_LIT: {
-    name: 'Google Lit',
-    id: 'google_lit',
-    forms: ['SAFE_SUPERFLUID_STREAM'],
-  },
+  // GOOGLE_LIT: {
+  //   name: 'Google Lit',
+  //   id: 'google_lit',
+  //   forms: ['SAFE_SUPERFLUID_STREAM'],
+  // },
 };
 
 export const defaultProposals = {

--- a/src/data/playlists.js
+++ b/src/data/playlists.js
@@ -62,11 +62,6 @@ export const BOOST_PLAYLISTS = {
     id: 'poster',
     forms: ['RATIFY_DAO_DOC', 'POST_IPFS_MD', 'POST_MD'],
   },
-  // GOOGLE_LIT: {
-  //   name: 'Google Lit',
-  //   id: 'google_lit',
-  //   forms: ['SAFE_SUPERFLUID_STREAM'],
-  // },
 };
 
 export const defaultProposals = {

--- a/src/data/playlists.js
+++ b/src/data/playlists.js
@@ -62,6 +62,11 @@ export const BOOST_PLAYLISTS = {
     id: 'poster',
     forms: ['RATIFY_DAO_DOC', 'POST_IPFS_MD', 'POST_MD'],
   },
+  GOOGLE_LIT: {
+    name: 'Google Lit',
+    id: 'google_lit',
+    forms: ['SAFE_SUPERFLUID_STREAM'],
+  },
 };
 
 export const defaultProposals = {

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link as RouterLink } from 'react-router-dom';
 import { RiAddFill } from 'react-icons/ri';
-import { Flex, Stack, Button, Link, Spinner } from '@chakra-ui/react';
+import { Flex, Stack, Button, Link, Spinner, VStack } from '@chakra-ui/react';
 import LitJsSdk from 'lit-js-sdk';
 import { useOverlay } from '../contexts/OverlayContext';
 import BoostNotActive from '../components/boostNotActive';
@@ -15,25 +15,30 @@ import {
   getSharedDaoGoogleDocs,
   STANDARD_CONTRACT_TYPE,
   loadStoredAuthSig,
-  deleteStoredAuthSig,
   signOutUser,
   handleLitServerError,
   redirectToLitOauthUI,
+  deleteStoredAuthSigs,
+  storeAuthSig,
+  LIT_API_HOST,
+  deleteShare,
 } from '../utils/litProtocol';
 import GoogleLitCard from '../components/GoogleLitCard';
+import { useInjectedProvider } from '../contexts/InjectedProviderContext';
 
 const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
   const { daoid, daochain } = useParams();
+  const { address } = useInjectedProvider();
   const [loading, setLoading] = useState(true);
-  const [googleDocs, setgoogleDocs] = useState({});
+  const [googleDocs, setgoogleDocs] = useState([]);
   const [showSignatureButton, setShowSignatureButton] = useState(true);
   const [authSig, setAuthSig] = useState(null);
   const [profile, setProfile] = useState(null);
-  const { errorToast, warningToast } = useOverlay();
+  const { errorToast, successToast } = useOverlay();
 
   useEffect(() => {
     const checkAndSetProfile = async () => {
-      const localAuthSig = loadStoredAuthSig();
+      const localAuthSig = loadStoredAuthSig(address);
 
       if (localAuthSig) {
         setAuthSig(localAuthSig);
@@ -42,33 +47,34 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
           setShowSignatureButton(false);
         }
       } else {
+        setAuthSig(null);
+        setProfile(null);
         setShowSignatureButton(true);
       }
     };
 
     checkAndSetProfile();
-  }, []);
+  }, [address]);
+
+  const getAllGoogleDocs = async () => {
+    try {
+      setgoogleDocs(await getSharedGoogleDocs(authSig, profile?.idOnService));
+      setShowSignatureButton(false);
+    } catch (err) {
+      console.log(err);
+      errorToast({
+        title: 'Fetching google docs failed',
+      });
+    }
+
+    setLoading(false);
+  };
 
   useEffect(() => {
     if (!profile || !daoMetaData?.boosts) {
       setLoading(false);
       return;
     }
-    const getAllGoogleDocs = async () => {
-      try {
-        setgoogleDocs(await getSharedGoogleDocs(authSig, profile?.idOnService));
-        setLoading(false);
-        setShowSignatureButton(false);
-      } catch (err) {
-        console.log(err);
-        setLoading(false);
-        errorToast({
-          title: 'Fetching google docs failed',
-        });
-      }
-
-      setLoading(false);
-    };
 
     if (daoMetaData && daoMetaData?.boosts?.GOOGLE_LIT.active && profile) {
       getAllGoogleDocs();
@@ -80,25 +86,28 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
     { chain } = { chain: 'ethereum' },
   ) => {
     let currentAuthSig = authSig;
-    if (!currentAuthSig) {
-      try {
-        console.log(chain);
-        currentAuthSig = await LitJsSdk.checkAndSignAuthMessage({
-          chain,
-        });
-        setAuthSig(currentAuthSig);
+    try {
+      let userExists;
+      currentAuthSig = await await LitJsSdk.checkAndSignAuthMessage({
+        chain,
+      });
+      storeAuthSig(currentAuthSig, address);
+      setAuthSig(currentAuthSig);
 
-        if (await checkIfUserExists(authSig)) {
-          return await callback(currentAuthSig);
-        } else {
-          throw 'User needs to authorize Lit through gogle UI';
-          // warningToast('Redirecting you to lit oauth connect UI');
-          // await redirectToLitOauthUI();
-          // return
-        }
-      } catch (e) {
-        return handleLitServerError(e);
+      userExists = await checkIfUserExists(currentAuthSig);
+      if (userExists) {
+        await callback(currentAuthSig);
+        return;
+      } else {
+        // TODO handle this case - create frontend user on Lit side..
+        // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L104
+        // warningToast({title: 'Redirecting you to lit oauth connect UI'});
+        // await redirectToLitOauthUI();
       }
+
+      await callback(currentAuthSig);
+    } catch (e) {
+      return handleLitServerError(e);
     }
   };
 
@@ -122,11 +131,13 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
 
   const handleSignOut = async () => {
     try {
-      await signOutUser();
-      deleteStoredAuthSig();
+      deleteStoredAuthSigs(address);
       setProfile(null);
       setAuthSig(null);
+      setgoogleDocs([]);
       setShowSignatureButton(true);
+      await LitJsSdk.disconnectWeb3();
+      await signOutUser(authSig);
     } catch (e) {
       console.log(e);
     }
@@ -137,12 +148,7 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
   const LitAuthSigButton = () =>
     isMember && (
       <Flex>
-        <Button
-          onClick={handleSignAuthMessage}
-          rightIcon={<RiAddFill />}
-          isExternal
-          mr={10}
-        >
+        <Button onClick={handleSignAuthMessage}>
           Authenticate Lit Protocol
         </Button>
       </Flex>
@@ -152,47 +158,58 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
     <Flex>
       <Button
         as={Link}
-        href={`https://oauth-app.litgateway.com/google?source=daohaus&dao_address=${daoMetaData?.address}&dao_name=${daoMetaData?.name}&contract_type=${STANDARD_CONTRACT_TYPE}`}
-        rightIcon={<RiAddFill />}
+        href={`${LIT_API_HOST}/google?source=daohaus&dao_address=${daoMetaData?.address}&dao_name=${daoMetaData?.name}&contract_type=${STANDARD_CONTRACT_TYPE}`}
         isExternal
         mr={10}
       >
         Share Google Drive Item
       </Button>
 
-      {profile && (
-        <Button onClick={handleSignOut} rightIcon={<RiAddFill />} mr={10}>
-          Sign Out
-        </Button>
-      )}
+      <Button onClick={handleSignOut} mr={10}>
+        Sign Out
+      </Button>
     </Flex>
   );
+
+  const handleDeleteShare = async shareInfo => {
+    try {
+      await deleteShare(shareInfo.id);
+      await getAllGoogleDocs();
+      successToast({ title: `${shareInfo.name} has been unshared.` });
+    } catch (err) {
+      console.log(`'Error deleting share', ${err}`);
+      errorToast({ title: 'Error deleting share', description: err });
+    }
+  };
+
+  const getLinkFromShare = async () => {
+    successToast({ title: 'Link has been copied to clipboard.' });
+  };
 
   return (
     <MainViewLayout
       header='Lit Protocol - Google Docs'
-      headerEl={Object.keys(googleDocs).length > 0 && addNewGoogleDoc}
+      headerEl={authSig && addNewGoogleDoc}
       isDao
     >
       <Flex as={Stack} direction='column' spacing={4} w='100%'>
-        {showSignatureButton && <LitAuthSigButton />}
         {!loading ? (
-          // daoMetaData && 'googleLit' in daoMetaData?.boosts ? (
-          daoMetaData && daoMetaData?.boosts?.GOOGLE_LIT?.active ? (
+          daoMetaData?.boosts?.GOOGLE_LIT?.active ? (
             Object.keys(googleDocs).length > 0 ? (
               Object.values(googleDocs)
                 .slice(0, 10)
-                .map(
-                  googleDoc =>
-                    googleDoc && (
-                      <GoogleLitCard
-                        key={googleDoc?.id}
-                        googleDoc={googleDoc}
-                      />
-                    ),
-                )
+                .map(googleDoc => (
+                  <GoogleLitCard
+                    key={googleDoc?.id}
+                    googleDoc={googleDoc}
+                    getLinkFromShare={getLinkFromShare}
+                    handleDeleteShare={handleDeleteShare}
+                    daoMetaData={daoMetaData}
+                  />
+                ))
             ) : (
-              <Flex mt='100px' w='100%' justify='center'>
+              <Flex as={VStack} mt='100px' w='100%' justify='center'>
+                {showSignatureButton && <LitAuthSigButton />}
                 <TextBox variant='value' size='lg'>
                   No Google Docs found.
                 </TextBox>
@@ -202,7 +219,9 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
             <BoostNotActive />
           )
         ) : (
-          <Spinner size='xl' />
+          <Flex mt='100px' w='100%' justify='center'>
+            <Spinner size='xl' />
+          </Flex>
         )}
       </Flex>
     </MainViewLayout>

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -12,7 +12,7 @@ import {
   checkIfUserExists,
   deleteShare,
   deleteStoredAuthSigs,
-  getSharedGoogleDocs,
+  getSharedDaoGoogleDocs,
   handleLitServerError,
   handleLoadCurrentUser,
   LIT_API_HOST,
@@ -60,7 +60,13 @@ const LitProtocolGoogle = ({ isMember, daoMetaData }) => {
 
   const getAllGoogleDocs = async () => {
     try {
-      setgoogleDocs(await getSharedGoogleDocs(authSig, profile?.idOnService));
+      setgoogleDocs(
+        await getSharedDaoGoogleDocs(
+          authSig,
+          profile?.idOnService,
+          daoMetaData?.contractAddress,
+        ),
+      );
       setShowSignatureButton(false);
     } catch (err) {
       console.log(err);

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -62,10 +62,13 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
   }, []);
 
   useEffect(() => {
+    console.log(daoMetaData?.contractAddress);
+    if (!daoMetaData?.contractAddress) return;
+
     const getAllGoogleDocs = async () => {
       try {
         setgoogleDocs(
-          await getAllSharedGoogleDocs(authSig, profile?.idOnService),
+          await getAllSharedGoogleDocs(daoMetaData.contractAddress),
         );
         setLoading(false);
       } catch (err) {
@@ -86,7 +89,12 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
     ) {
       getAllGoogleDocs();
     }
-  }, [daoMetaData?.boosts, authSig, profile?.idOnService]);
+  }, [
+    daoMetaData?.boosts,
+    authSig,
+    profile?.idOnService,
+    !daoMetaData?.contractAddress,
+  ]);
 
   const performWithAuthSig = async (
     callback,

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -1,0 +1,288 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link as RouterLink } from 'react-router-dom';
+import { RiAddFill } from 'react-icons/ri';
+import { Flex, Stack, Button, Link, Spinner } from '@chakra-ui/react';
+
+import { useOverlay } from '../contexts/OverlayContext';
+import BoostNotActive from '../components/boostNotActive';
+import MainViewLayout from '../components/mainViewLayout';
+import SnapshotCard from '../components/snapshotCard';
+import TextBox from '../components/TextBox';
+
+const STANDARD_CONTRACT_TYPE = 'MolochDAOv2.1';
+const LIT_API_HOST = ''; // TODO get lit protocol host endpoint
+
+const checkIfUserExists = async authSig => {
+  // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L172-L194
+  try {
+    const response = await fetch(
+      `${LIT_API_HOST}/api/google/checkIfUserExists`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          authSig,
+        }),
+      },
+    );
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+const getUserProfile = async authSig => {
+  try {
+    const response = await fetch(`${LIT_API_HOST}/api/google/getUserProfile`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ authSig }),
+    });
+
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+// if accessToken is necessary for certain calls (potentially "unshare" document)
+const handleLoadCurrentUser = async authSig => {
+  const userInfo = await getUserProfile(authSig);
+  // check for google drive scope and sign user out if scope is not present
+  if (
+    userInfo.data['scope'] &&
+    userInfo.data['scope'].includes(
+      'https://www.googleapis.com/auth/drive.file',
+    )
+  ) {
+    const profileData = JSON.parse(userInfo.data.extraData);
+    const accessToken = profileData.accessToken; // if we need jwt access token for some api call
+    const userProfile = {
+      idOnService: userInfo.data.idOnService,
+      email: userInfo.data.email,
+      displayName: profileData.displayName,
+      avatar: profileData.photoLink,
+    };
+
+    await getAllSharedGoogleDocs(authSig, userProfile.idOnService);
+  }
+};
+
+export const getAllSharedGoogleDocs = async (authSig, idOnService) => {
+  try {
+    const response = await fetch(`${API_HOST}/api/google/getAllShares`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        authSig,
+        idOnService,
+      }),
+    });
+
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
+  const { daoid, daochain } = useParams();
+  const [loading, setLoading] = useState(true);
+  const [googleDocs, setgoogleDocs] = useState({});
+  const [showSignatureButton, setShowSignatureButton] = useState(false);
+  const [authSig, setAuthSig] = useState(null);
+  const { errorToast } = useOverlay();
+
+  useEffect(() => {
+    const localAuthSig = localStorage.getItem('authSig');
+
+    if (localAuthSig) {
+      setAuthSig(localAuthSig);
+      checkIfUserExists(authSig)
+        .then(res => {
+          if (res.data.status === 'success') {
+            handleLoadCurrentUser(authSig);
+            setShowSignatureButton(false);
+          } else {
+            errorToast(res.data.message);
+          }
+        })
+        .catch(err => {
+          errorToast(err.message);
+        });
+    } else {
+      setShowSignatureButton(true);
+    }
+  }, [authSig]);
+
+  useEffect(() => {
+    const getAllGoogleDocs = async () => {
+      try {
+        const localgoogleDocs = await getAllSharedGoogleDocs();
+        //   // daoMetaData?.boosts?.snapshot.metadata.space,
+        //   daoMetaData?.boosts?.SNAPSHOT.metadata.space,
+        // );
+        setgoogleDocs(localgoogleDocs);
+        setLoading(false);
+      } catch (err) {
+        console.log(err);
+        setLoading(false);
+        errorToast({
+          title: 'Fetching google docs failed',
+        });
+      }
+    };
+    if (
+      daoMetaData &&
+      // 'snapshot' in daoMetaData?.boosts &&
+      // daoMetaData?.boosts?.snapshot.active
+      'GOOGLE_LIT' in daoMetaData?.boosts &&
+      daoMetaData?.boosts?.GOOGLE_LIT.active
+    ) {
+      getAllGoogleDocs();
+    }
+  }, [daoMetaData?.boosts]);
+
+  const addNewGoogleDoc = isMember && (
+    <Flex>
+      <Button
+        as={Link}
+        href={`https://oauth-app.litgateway.com/google?source=daohaus&dao_address=${daoMetaData?.address}&dao_name=${daoMetaData?.name}&contract_type=${STANDARD_CONTRACT_TYPE}`}
+        rightIcon={<RiAddFill />}
+        isExternal
+        mr={10}
+      >
+        Share Google Drive Item
+      </Button>
+      {/*
+      <Button
+        as={RouterLink}
+        to={`/dao/${daochain}/${daoid}/boost/snapshot/settings`}
+      >
+        Boost Settings
+      </Button> */}
+    </Flex>
+  );
+
+  const performWithAuthSig = async (
+    callback,
+    { chain } = { chain: 'ethereum' },
+  ) => {
+    let currentAuthSig = authSig;
+    if (!currentAuthSig) {
+      try {
+        currentAuthSig = await LitJsSdk.checkAndSignAuthMessage({ chain });
+        setAuthSig(currentAuthSig);
+      } catch (e) {
+        if (e.code === 4001) {
+          // redirect to lit oauth connect UI
+          // window.location = 'https://litgateway.com/apps';
+          errorToast({
+            title: 'Could not connect to Lit Protocol -> redirect',
+          });
+          return;
+        }
+        if (e?.errorCode === 'no_wallet') {
+          errorToast({ title: 'You need a wallet to use the Lit Protocol' });
+          return false;
+        } else if (e?.errorCode === 'wrong_network') {
+          errorToast({ title: e.message });
+          return false;
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    return await callback(currentAuthSig);
+  };
+
+  const handleSignAuthMessage = async () => {
+    await performWithAuthSig(
+      authSig => {
+        handleLoadCurrentUser(authSig);
+      },
+      { chain: daoMetaData?.chain },
+    );
+  };
+
+  const LitAuthSigButton = isMember && (
+    <Flex>
+      <Button
+        onClick={handleSignAuthMessage}
+        href={`https://oauth-app.litgateway.com/google?source=daohaus&dao_address=${daoMetaData?.address}&dao_name=${daoMetaData?.name}&contract_type=${STANDARD_CONTRACT_TYPE}`}
+        rightIcon={<RiAddFill />}
+        isExternal
+        mr={10}
+      >
+        Share Google Drive Item
+      </Button>
+      {/*
+      <Button
+        as={RouterLink}
+        to={`/dao/${daochain}/${daoid}/boost/lit-protocol/google/settings`}
+      >
+        Boost Settings
+      </Button> */}
+    </Flex>
+  );
+
+  return (
+    <MainViewLayout
+      header='Lit Protocol - Google Docs'
+      headerEl={Object.keys(googleDocs).length > 0 && addNewGoogleDoc}
+      isDao
+    >
+      {showSignatureButton ? (
+        <Flex justify='space-between' py='2'>
+          <Flex
+            as={Link}
+            to={`/dao/${daochain}/${daoid}/vaults`}
+            align='center'
+            mb={3}
+          >
+            <Icon as={BiArrowBack} color='secondary.500' mr={2} />
+            All Vaults
+          </Flex>
+        </Flex>
+      ) : (
+        <Flex as={Stack} direction='column' spacing={4} w='100%'>
+          {!loading ? (
+            // daoMetaData && 'googleLit' in daoMetaData?.boosts ? (
+            daoMetaData && 'GOOGLE_LIT' in daoMetaData?.boosts ? (
+              Object.keys(googleDocs).length > 0 ? (
+                Object.values(googleDocs)
+                  .slice(0, 10)
+                  .map(googleLit => ({
+                    /* <SnapshotCard
+                      key={googleLit.id}
+                      googleLitId={googleLit.od}
+                      googleLit={googleLit}
+                    /> */
+                  }))
+              ) : (
+                <Flex mt='100px' w='100%' justify='center'>
+                  <TextBox variant='value' size='lg'>
+                    No Google Docs found.
+                  </TextBox>
+                </Flex>
+              )
+            ) : (
+              <BoostNotActive />
+            )
+          ) : (
+            <Spinner size='xl' />
+          )}
+        </Flex>
+      )}
+    </MainViewLayout>
+  );
+};
+
+export default LitProtocolGoogle;

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -47,7 +47,6 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
       setLoading(false);
       return;
     }
-    console.log(profile?.idOnService, authSig?.sig, daoMetaData?.boosts);
     const getAllGoogleDocs = async () => {
       try {
         setgoogleDocs(await getSharedGoogleDocs(authSig, profile?.idOnService));
@@ -64,20 +63,14 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
       setLoading(false);
     };
 
-    console.log(
-      daoMetaData,
-      daoMetaData?.boosts?.GOOGLE_LIT.active,
-      profile?.idOnService,
-      authSig?.sig,
-
-      'isTrue?',
+    if (
       daoMetaData &&
-        daoMetaData?.boosts?.GOOGLE_LIT.active &&
-        profile?.idOnService &&
-        authSig?.sig,
-    );
-
-    getAllGoogleDocs();
+      daoMetaData?.boosts?.GOOGLE_LIT.active &&
+      profile?.idOnService &&
+      authSig?.sig
+    ) {
+      getAllGoogleDocs();
+    }
   }, [daoMetaData, authSig, profile]);
 
   const performWithAuthSig = async (
@@ -86,7 +79,6 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
   ) => {
     let currentAuthSig = authSig;
     if (!currentAuthSig) {
-      // console.log(litProtocolClient);
       try {
         currentAuthSig = await LitJsSdk.checkAndSignAuthMessage({
           chain,
@@ -119,7 +111,6 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
 
   const handleSignAuthMessage = async () => {
     setLoading(true);
-    console.log('chain', daoMetaData);
     await performWithAuthSig(
       async authSig => {
         const user = await handleLoadCurrentUser(authSig);
@@ -150,7 +141,7 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
           isExternal
           mr={10}
         >
-          Sign
+          Sign In
         </Button>
       </Flex>
     );
@@ -180,7 +171,6 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
     </Flex>
   );
 
-  console.log(daoMetaData);
   return (
     <MainViewLayout
       header='Lit Protocol - Google Docs'
@@ -191,7 +181,7 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
         {showSignatureButton && <LitAuthSigButton />}
         {!loading ? (
           // daoMetaData && 'googleLit' in daoMetaData?.boosts ? (
-          daoMetaData ? (
+          daoMetaData && daoMetaData?.boosts?.GOOGLE_LIT?.active ? (
             Object.keys(googleDocs).length > 0 ? (
               Object.values(googleDocs)
                 .slice(0, 10)
@@ -203,11 +193,6 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
                         googleDoc={googleDoc}
                       />
                     ),
-                  /* <SnapshotCard
-                      key={googleLit.id}
-                      googleLitId={googleLit.od}
-                      googleLit={googleLit}
-                    /> */
                 )
             ) : (
               <Flex mt='100px' w='100%' justify='center'>

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -15,7 +15,8 @@ import {
   getSharedDaoGoogleDocs,
   STANDARD_CONTRACT_TYPE,
   loadStoredAuthSig,
-  googleLitSignOut,
+  deleteStoredAuthSig,
+  signOutUser,
 } from '../utils/litProtocol';
 import GoogleLitCard from '../components/GoogleLitCard';
 
@@ -43,7 +44,7 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
   }, []);
 
   useEffect(() => {
-    if (!profile?.idOnService || !authSig?.sig || !daoMetaData?.boosts) {
+    if (!profile || !daoMetaData?.boosts) {
       setLoading(false);
       return;
     }
@@ -63,15 +64,10 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
       setLoading(false);
     };
 
-    if (
-      daoMetaData &&
-      daoMetaData?.boosts?.GOOGLE_LIT.active &&
-      profile?.idOnService &&
-      authSig?.sig
-    ) {
+    if (daoMetaData && daoMetaData?.boosts?.GOOGLE_LIT.active) {
       getAllGoogleDocs();
     }
-  }, [daoMetaData, authSig, profile]);
+  }, [daoMetaData?.boosts, authSig, profile]);
 
   const performWithAuthSig = async (
     callback,
@@ -124,10 +120,15 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
   };
 
   const handleSignOut = async () => {
-    googleLitSignOut();
-    setProfile(null);
-    setAuthSig(null);
-    setShowSignatureButton(true);
+    try {
+      await signOutUser();
+      deleteStoredAuthSig();
+      setProfile(null);
+      setAuthSig(null);
+      setShowSignatureButton(true);
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   console.log(googleDocs);
@@ -141,7 +142,7 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
           isExternal
           mr={10}
         >
-          Sign In
+          Authenticate Lit Protocol
         </Button>
       </Flex>
     );

--- a/src/pages/LitProtocolGoogle.jsx
+++ b/src/pages/LitProtocolGoogle.jsx
@@ -1,18 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, Link as RouterLink } from 'react-router-dom';
-import { RiAddFill } from 'react-icons/ri';
 import { Flex, Stack, Button, Link, Spinner, VStack } from '@chakra-ui/react';
 import LitJsSdk from 'lit-js-sdk';
 import { useOverlay } from '../contexts/OverlayContext';
 import BoostNotActive from '../components/boostNotActive';
 import MainViewLayout from '../components/mainViewLayout';
-import SnapshotCard from '../components/snapshotCard';
 import TextBox from '../components/TextBox';
 import {
   checkIfUserExists,
   handleLoadCurrentUser,
   getSharedGoogleDocs,
-  getSharedDaoGoogleDocs,
+  getSharedDaoGoogleDocs, // to be used when Lit has functionality hooked up.
   STANDARD_CONTRACT_TYPE,
   loadStoredAuthSig,
   signOutUser,
@@ -26,15 +23,14 @@ import {
 import GoogleLitCard from '../components/GoogleLitCard';
 import { useInjectedProvider } from '../contexts/InjectedProviderContext';
 
-const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
-  const { daoid, daochain } = useParams();
+const LitProtocolGoogle = ({ isMember, daoMetaData }) => {
   const { address } = useInjectedProvider();
   const [loading, setLoading] = useState(true);
   const [googleDocs, setgoogleDocs] = useState([]);
   const [showSignatureButton, setShowSignatureButton] = useState(true);
   const [authSig, setAuthSig] = useState(null);
   const [profile, setProfile] = useState(null);
-  const { errorToast, successToast } = useOverlay();
+  const { errorToast, warningToast, successToast } = useOverlay();
 
   useEffect(() => {
     const checkAndSetProfile = async () => {
@@ -101,8 +97,8 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
       } else {
         // TODO handle this case - create frontend user on Lit side..
         // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L104
-        // warningToast({title: 'Redirecting you to lit oauth connect UI'});
-        // await redirectToLitOauthUI();
+        warningToast({ title: 'Redirecting you to lit oauth connect UI' });
+        await redirectToLitOauthUI();
       }
 
       await callback(currentAuthSig);
@@ -204,7 +200,6 @@ const LitProtocolGoogle = ({ isMember, daoMetaData, refetchMetaData }) => {
                     googleDoc={googleDoc}
                     getLinkFromShare={getLinkFromShare}
                     handleDeleteShare={handleDeleteShare}
-                    daoMetaData={daoMetaData}
                   />
                 ))
             ) : (

--- a/src/routers/daoRouter.jsx
+++ b/src/routers/daoRouter.jsx
@@ -41,7 +41,7 @@ import ProposalsSpam from '../pages/ProposalsSpam';
 import SpamFilterSettings from '../pages/SpamFilterSettings';
 import DaoDocs from '../pages/daoDocs';
 import DaoDoc from '../pages/DaoDoc';
-// import LitProtocolGoogle from '../pages/LitProtocolGoogle';
+import LitProtocolGoogle from '../pages/LitProtocolGoogle';
 
 const DaoRouter = () => {
   const { path } = useRouteMatch();
@@ -243,15 +243,14 @@ const DaoRouter = () => {
           />
         </Route>
         {/*
-          TODO commenting out until we hear back from Lit on remaining integration items.
-          see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897
-          for more details.
-
+          TODO adding a flag to activate the LIT integration until the Lit team gets back to us
+          see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897 for more details.
+        */}
+        {process.env.REACT_APP_DEV && (
           <Route exact path={`${path}/boost/lit-protocol/google`}>
             <LitProtocolGoogle isMember={isMember} daoMetaData={daoMetaData} />
           </Route>
-        */}
-
+        )}
         <Route exact path={`${path}/party-favor`}>
           <PartyFavor isMember={isMember} />
         </Route>

--- a/src/routers/daoRouter.jsx
+++ b/src/routers/daoRouter.jsx
@@ -41,7 +41,7 @@ import ProposalsSpam from '../pages/ProposalsSpam';
 import SpamFilterSettings from '../pages/SpamFilterSettings';
 import DaoDocs from '../pages/daoDocs';
 import DaoDoc from '../pages/DaoDoc';
-import LitProtocolGoogle from '../pages/LitProtocolGoogle';
+// import LitProtocolGoogle from '../pages/LitProtocolGoogle';
 
 const DaoRouter = () => {
   const { path } = useRouteMatch();
@@ -242,9 +242,15 @@ const DaoRouter = () => {
             refetchMetaData={refetchMetaData}
           />
         </Route>
-        <Route exact path={`${path}/boost/lit-protocol/google`}>
-          <LitProtocolGoogle isMember={isMember} daoMetaData={daoMetaData} />
-        </Route>
+        {/*
+          TODO commenting out until we hear back from Lit on remaining integration items.
+          see latest comments on https://github.com/HausDAO/daohaus-app/pull/1897
+          for more details.
+
+          <Route exact path={`${path}/boost/lit-protocol/google`}>
+            <LitProtocolGoogle isMember={isMember} daoMetaData={daoMetaData} />
+          </Route>
+        */}
 
         <Route exact path={`${path}/party-favor`}>
           <PartyFavor isMember={isMember} />

--- a/src/routers/daoRouter.jsx
+++ b/src/routers/daoRouter.jsx
@@ -41,6 +41,7 @@ import ProposalsSpam from '../pages/ProposalsSpam';
 import SpamFilterSettings from '../pages/SpamFilterSettings';
 import DaoDocs from '../pages/daoDocs';
 import DaoDoc from '../pages/DaoDoc';
+import LitProtocolGoogle from '../pages/LitProtocolGoogle';
 
 const DaoRouter = () => {
   const { path } = useRouteMatch();
@@ -241,6 +242,20 @@ const DaoRouter = () => {
             refetchMetaData={refetchMetaData}
           />
         </Route>
+        {/* <Route exact path={`${path}/boost/lit-protocol/google/settings`}>
+          <LitProtocolGoogleSettings
+            daoMetaData={daoMetaData}
+            refetchMetaData={refetchMetaData}
+          />
+        </Route> */}
+        <Route exact path={`${path}/boost/lit-protocol/google`}>
+          <LitProtocolGoogle
+            isMember={isMember}
+            daoMetaData={daoMetaData}
+            refetchMetaData={refetchMetaData}
+          />
+        </Route>
+
         <Route exact path={`${path}/party-favor`}>
           <PartyFavor isMember={isMember} />
         </Route>

--- a/src/routers/daoRouter.jsx
+++ b/src/routers/daoRouter.jsx
@@ -242,12 +242,6 @@ const DaoRouter = () => {
             refetchMetaData={refetchMetaData}
           />
         </Route>
-        {/* <Route exact path={`${path}/boost/lit-protocol/google/settings`}>
-          <LitProtocolGoogleSettings
-            daoMetaData={daoMetaData}
-            refetchMetaData={refetchMetaData}
-          />
-        </Route> */}
         <Route exact path={`${path}/boost/lit-protocol/google`}>
           <LitProtocolGoogle
             isMember={isMember}

--- a/src/routers/daoRouter.jsx
+++ b/src/routers/daoRouter.jsx
@@ -243,11 +243,7 @@ const DaoRouter = () => {
           />
         </Route>
         <Route exact path={`${path}/boost/lit-protocol/google`}>
-          <LitProtocolGoogle
-            isMember={isMember}
-            daoMetaData={daoMetaData}
-            refetchMetaData={refetchMetaData}
-          />
+          <LitProtocolGoogle isMember={isMember} daoMetaData={daoMetaData} />
         </Route>
 
         <Route exact path={`${path}/party-favor`}>

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -166,9 +166,15 @@ export const getSharedGoogleDocs = async (authSig, idOnService) => {
   });
 };
 
-export const getSharedDaoGoogleDocs = async daoAddress => {
-  // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L398
+export const getSharedDaoGoogleDocs = async (
+  authSig,
+  idOnService,
+  daoAddress,
+) => {
+  // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L401
   return await handleLitRequest('api/google/getDAOShares', 'POST', {
+    authSig,
+    idOnService,
     daoAddress,
     source: 'daohaus',
   });

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -1,5 +1,5 @@
 export const STANDARD_CONTRACT_TYPE = 'MolochDAOv2.1';
-export const LIT_API_HOST = 'https://oauth-app.litgateway.com'; // TODO get lit protocol host endpoint
+export const LIT_API_HOST = 'https://oauth-app.litgateway.com';
 const AUTH_SIG_STORAGE_KEY = 'lit-auth-signature';
 
 // https://developer.litprotocol.com/docs/LitTools/JSSDK/errorHandling
@@ -52,7 +52,7 @@ export const getAssetType = assetTypeScope => {
   return assetTypeScope.split('google-apps.')[1];
 };
 
-const handleServerLitError = e => {
+export const handleLitServerError = e => {
   if (e.code === 4001) {
     // redirect to lit oauth connect UI
     // window.location = 'https://litgateway.com/apps';
@@ -76,24 +76,30 @@ const handleServerLitError = e => {
   }
 };
 
-// export const loadLitProtocol = async () => {
-//   // potentially build a client incorporate error handling
-//   // https://developer.litprotocol.com/docs/LitTools/JSSDK/errorHandling
-//   const client = new LitJsSdk.LitNodeClient();
-//   await client.connect();
-// };
+export const redirectToLitOauthUI = async () => {
+  window.location.replace('https://oauth-app.litgateway.com/google');
+};
 
-// export const signLitAuth = async chain => {
-//   try {
-//     return await litProtocolClient.checkAndSignAuthMessage({
-//       chain,
-//     });
-//     // storeAuthSig(currentAuthSig);
-//     // setAuthSig(currentAuthSig);
-//   } catch (e) {
-//     return handleServerLitError(e);
-//   }
-// };
+export const handleLoadCurrentUser = async authSig => {
+  const userInfo = await getUserProfile(authSig);
+  // check for google drive scope and sign user out if scope is not present
+  if (
+    userInfo['scope'] &&
+    userInfo['scope'].includes('https://www.googleapis.com/auth/drive.file')
+  ) {
+    const profileData = JSON.parse(userInfo.extraData);
+    // if accessToken is necessary for certain calls (potentially "unshare" document)
+    // const accessToken = profileData.accessToken; // if we need jwt access token for some api call
+    const userProfile = {
+      idOnService: userInfo.idOnService,
+      email: userInfo.email,
+      displayName: profileData.displayName,
+      avatar: profileData.photoLink,
+    };
+
+    return userProfile;
+  }
+};
 
 export const checkIfUserExists = async authSig => {
   try {
@@ -184,26 +190,5 @@ export const getSharedDaoGoogleDocs = async daoAddress => {
     return response.json();
   } catch (err) {
     throw new Error(err);
-  }
-};
-
-export const handleLoadCurrentUser = async authSig => {
-  const userInfo = await getUserProfile(authSig);
-  // check for google drive scope and sign user out if scope is not present
-  if (
-    userInfo['scope'] &&
-    userInfo['scope'].includes('https://www.googleapis.com/auth/drive.file')
-  ) {
-    const profileData = JSON.parse(userInfo.extraData);
-    // if accessToken is necessary for certain calls (potentially "unshare" document)
-    // const accessToken = profileData.accessToken; // if we need jwt access token for some api call
-    const userProfile = {
-      idOnService: userInfo.idOnService,
-      email: userInfo.email,
-      displayName: profileData.displayName,
-      avatar: profileData.photoLink,
-    };
-
-    return userProfile;
   }
 };

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -27,17 +27,20 @@ const USER_ERROR_CODE_MAP = {
 // using wallet address allows for more than one lit auth sig to be stored at a time,
 // ie a user can use different wallets without conflicting keys
 const AUTH_SIG_STORAGE_KEY = 'lit-auth-signature';
-const buildAuthSigKey = walletAddress => {
-  return `${AUTH_SIG_STORAGE_KEY}-${walletAddress}`;
+const buildAuthSigKey = (walletAddress, daoAddress) => {
+  return `${AUTH_SIG_STORAGE_KEY}-${walletAddress}-${daoAddress}`;
 };
 
-export const storeAuthSig = (authSig, walletAddress) => {
-  localStorage.setItem(buildAuthSigKey(walletAddress), JSON.stringify(authSig));
+export const storeAuthSig = (authSig, walletAddress, daoAddress) => {
+  localStorage.setItem(
+    buildAuthSigKey(walletAddress, daoAddress),
+    JSON.stringify(authSig),
+  );
 };
 
-export const loadStoredAuthSig = walletAddress => {
+export const loadStoredAuthSig = (walletAddress, daoAddress) => {
   const authSig = JSON.parse(
-    localStorage.getItem(buildAuthSigKey(walletAddress)),
+    localStorage.getItem(buildAuthSigKey(walletAddress, daoAddress)),
   );
 
   if (authSig) {
@@ -49,8 +52,8 @@ export const loadStoredAuthSig = walletAddress => {
   return authSig;
 };
 
-export const deleteStoredAuthSigs = walletAddress => {
-  localStorage.removeItem(buildAuthSigKey(walletAddress));
+export const deleteStoredAuthSigs = (walletAddress, daoAddress) => {
+  localStorage.removeItem(buildAuthSigKey(walletAddress, daoAddress));
   localStorage.removeItem(AUTH_SIG_STORAGE_KEY);
 };
 

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -14,6 +14,7 @@ const LIT_DAO_HAUS_ERROR_MAP = [
   'invalid_unified_condition_type',
   'unknown_error',
 ];
+
 const USER_ERROR_CODE_MAP = {
   no_wallet: 'You need a wallet to use the Lit Protocol',
   not_authorized: 'You are not authorized to view this page',

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -118,18 +118,20 @@ export const getUserProfile = async authSig => {
   }
 };
 
-export const getAllSharedGoogleDocs = async (authSig, idOnService) => {
+export const getAllSharedGoogleDocs = async daoAddress => {
   try {
-    const response = await fetch(`${LIT_API_HOST}/api/google/getAllShares`, {
+    const response = await fetch(`${LIT_API_HOST}/api/google/getDAOShares`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        authSig,
-        idOnService,
-      }),
+      body: JSON.stringify({ daoAddress, source: 'daohaus' }),
     });
+
+    // body: JSON.stringify({
+    //   authSig,
+    //   idOnService,
+    // }),
 
     return response.json();
   } catch (err) {

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -118,109 +118,62 @@ export const handleLoadCurrentUser = async authSig => {
   }
 };
 
-export const checkIfUserExists = async authSig => {
+export const handleLitRequest = async (endpoint, method, body) => {
   try {
-    // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L104-L170
-    const response = await fetch(
-      `${LIT_API_HOST}/api/google/checkIfUserExists`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          authSig,
-        }),
+    const response = await fetch(`${LIT_API_HOST}/${endpoint}`, {
+      method: method,
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+      body: JSON.stringify(body),
+    });
+
     return response.json();
   } catch (err) {
     throw new Error(err);
   }
+};
+
+export const checkIfUserExists = async authSig => {
+  // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L104-L170
+  return await handleLitRequest('api/google/checkIfUserExists', 'POST', {
+    authSig,
+  });
 };
 
 export const getUserProfile = async authSig => {
-  try {
-    // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L172-L194
-    const response = await fetch(`${LIT_API_HOST}/api/google/getUserProfile`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ authSig }),
-    });
-
-    return response.json();
-  } catch (err) {
-    throw new Error(err);
-  }
+  // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L172-L194
+  return await handleLitRequest('api/google/getUserProfile', 'POST', {
+    authSig,
+  });
 };
 
 export const signOutUser = async authSig => {
-  try {
-    // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L381
-    const response = await fetch(`${LIT_API_HOST}/api/google/signOutUser`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ authSig }),
-    });
-
-    return response.json();
-  } catch (err) {
-    throw new Error(err);
-  }
+  // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L381
+  return await handleLitRequest('api/google/signOutUser', 'POST', {
+    authSig,
+  });
 };
 
 export const getSharedGoogleDocs = async (authSig, idOnService) => {
-  try {
-    // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L196
-    const response = await fetch(`${LIT_API_HOST}/api/google/getAllShares`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        authSig,
-        idOnService,
-      }),
-    });
-
-    return response.json();
-  } catch (err) {
-    throw new Error(err);
-  }
+  // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L196
+  return await handleLitRequest('api/google/getAllShares', 'POST', {
+    authSig,
+    idOnService,
+  });
 };
 
 export const getSharedDaoGoogleDocs = async daoAddress => {
-  try {
-    // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L398
-    const response = await fetch(`${LIT_API_HOST}/api/google/getDAOShares`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ daoAddress, source: 'daohaus' }),
-    });
-
-    return response.json();
-  } catch (err) {
-    throw new Error(err);
-  }
+  // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L398
+  return await handleLitRequest('api/google/getDAOShares', 'POST', {
+    daoAddress,
+    source: 'daohaus',
+  });
 };
 
 export const deleteShare = async shareUuid => {
-  try {
-    const response = await fetch(`${LIT_API_HOST}/api/google/deleteShare`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ uuid: shareUuid }),
-    });
-    return response.json();
-  } catch (err) {
-    throw new Error(err);
-  }
+  // https://github.com/LIT-Protocol/lit-oauth/blob/main/server/oauth/google.js#L398
+  return await handleLitRequest('api/google/deleteShare', 'POST', {
+    uuid: shareUuid,
+  });
 };

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -153,7 +153,7 @@ export const handleLoadCurrentUser = async authSig => {
       displayName: profileData.displayName,
       avatar: profileData.photoLink,
     };
-    console.log('info:::::', userInfo, userProfile);
-    await getAllSharedGoogleDocs(authSig, userProfile.idOnService);
+
+    return userProfile;
   }
 };

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -1,0 +1,92 @@
+export const STANDARD_CONTRACT_TYPE = 'MolochDAOv2.1';
+export const LIT_API_HOST = ''; // TODO get lit protocol host endpoint
+
+const AUTH_SIG_STORAGE_KEY = 'lit-protocol-auth-sig';
+
+export const storeAuthSig = authSig => {
+  localStorage.setItem(AUTH_SIG_STORAGE_KEY, JSON.stringify(authSig));
+};
+
+export const loadStoredAuthSig = () => {
+  return JSON.parse(localStorage.getItem(AUTH_SIG_STORAGE_KEY));
+};
+
+export const checkIfUserExists = async authSig => {
+  // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L104-L170
+  try {
+    const response = await fetch(
+      `${LIT_API_HOST}/api/google/checkIfUserExists`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          authSig,
+        }),
+      },
+    );
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const getUserProfile = async authSig => {
+  // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L172-L194
+  try {
+    const response = await fetch(`${LIT_API_HOST}/api/google/getUserProfile`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ authSig }),
+    });
+
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const getAllSharedGoogleDocs = async (authSig, idOnService) => {
+  try {
+    const response = await fetch(`${LIT_API_HOST}/api/google/getAllShares`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        authSig,
+        idOnService,
+      }),
+    });
+
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const handleLoadCurrentUser = async authSig => {
+  const userInfo = await getUserProfile(authSig);
+  // check for google drive scope and sign user out if scope is not present
+  if (
+    userInfo.data['scope'] &&
+    userInfo.data['scope'].includes(
+      'https://www.googleapis.com/auth/drive.file',
+    )
+  ) {
+    const profileData = JSON.parse(userInfo.data.extraData);
+    // if accessToken is necessary for certain calls (potentially "unshare" document)
+    // const accessToken = profileData.accessToken; // if we need jwt access token for some api call
+    const userProfile = {
+      idOnService: userInfo.data.idOnService,
+      email: userInfo.data.email,
+      displayName: profileData.displayName,
+      avatar: profileData.photoLink,
+    };
+
+    await getAllSharedGoogleDocs(authSig, userProfile.idOnService);
+  }
+};

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -1,15 +1,84 @@
 export const STANDARD_CONTRACT_TYPE = 'MolochDAOv2.1';
-export const LIT_API_HOST = ''; // TODO get lit protocol host endpoint
+export const LIT_API_HOST = 'https://oauth-app.litgateway.com'; // TODO get lit protocol host endpoint
+const AUTH_SIG_STORAGE_KEY = 'lit-auth-signature';
 
-const AUTH_SIG_STORAGE_KEY = 'lit-protocol-auth-sig';
+// https://developer.litprotocol.com/docs/LitTools/JSSDK/errorHandling
+const LIT_DAO_HAUS_ERROR_MAP = [
+  'missing_access_control_conditions',
+  'incorrect_access_control_conditions',
+  'storage_error',
+  'resource_id_not_found',
+  'encrypted_symmetric_key_not_found',
+  'iat_outside_grace_period',
+  'exp_wrong_or_too_large',
+  'lit_node_client_not_ready',
+  'invalid_unified_condition_type',
+  'unknown_error',
+];
+const USER_ERROR_CODE_MAP = {
+  no_wallet: 'You need a wallet to use the Lit Protocol',
+  not_authorized: 'You are not authorized to view this page',
+  access_control_conditions_check_failed:
+    'there are issues with connecting to the current chain',
+  invalid_auth_sig:
+    'There was an issue with your authentication signature, please reauthenticate',
+  rpc_error: 'There are issues talking to the chain, please try again later',
+};
 
-export const storeAuthSig = authSig => {
-  localStorage.setItem(AUTH_SIG_STORAGE_KEY, JSON.stringify(authSig));
+export const getLitStorageKey = daoAddress => {
+  return `${AUTH_SIG_STORAGE_KEY}-${daoAddress}`;
+};
+
+export const storeAuthSig = (authSig, daoAddress) => {
+  localStorage.setItem(getLitStorageKey(daoAddress), JSON.stringify(authSig));
 };
 
 export const loadStoredAuthSig = () => {
   return JSON.parse(localStorage.getItem(AUTH_SIG_STORAGE_KEY));
 };
+
+const handleServerLitError = e => {
+  if (e.code === 4001) {
+    // redirect to lit oauth connect UI
+    // window.location = 'https://litgateway.com/apps';
+    return new Error('Could not connect to Lit Protocol');
+  }
+
+  if (e?.errorCode === 'wrong_network') {
+    return new Error(e.message);
+  }
+
+  if (e?.errorCode in LIT_DAO_HAUS_ERROR_MAP) {
+    console.error(e);
+    return new Error('cannot process action');
+  }
+
+  if (e.errorCode in Object.keys(USER_ERROR_CODE_MAP)) {
+    return new Error(USER_ERROR_CODE_MAP[e.errorCode]);
+  } else {
+    console.log(e);
+    throw e;
+  }
+};
+
+// export const loadLitProtocol = async () => {
+//   // potentially build a client incorporate error handling
+//   // https://developer.litprotocol.com/docs/LitTools/JSSDK/errorHandling
+//   const client = new LitJsSdk.LitNodeClient();
+//   await client.connect();
+// };
+
+// export const signLitAuth = async chain => {
+//   try {
+//     return await litProtocolClient.checkAndSignAuthMessage({
+//       chain,
+//     });
+//     // storeAuthSig(currentAuthSig);
+//     // setAuthSig(currentAuthSig);
+//   } catch (e) {
+//     return handleServerLitError(e);
+//   }
+// };
 
 export const checkIfUserExists = async authSig => {
   // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L104-L170
@@ -72,21 +141,19 @@ export const handleLoadCurrentUser = async authSig => {
   const userInfo = await getUserProfile(authSig);
   // check for google drive scope and sign user out if scope is not present
   if (
-    userInfo.data['scope'] &&
-    userInfo.data['scope'].includes(
-      'https://www.googleapis.com/auth/drive.file',
-    )
+    userInfo['scope'] &&
+    userInfo['scope'].includes('https://www.googleapis.com/auth/drive.file')
   ) {
-    const profileData = JSON.parse(userInfo.data.extraData);
+    const profileData = JSON.parse(userInfo.extraData);
     // if accessToken is necessary for certain calls (potentially "unshare" document)
     // const accessToken = profileData.accessToken; // if we need jwt access token for some api call
     const userProfile = {
-      idOnService: userInfo.data.idOnService,
-      email: userInfo.data.email,
+      idOnService: userInfo.idOnService,
+      email: userInfo.email,
       displayName: profileData.displayName,
       avatar: profileData.photoLink,
     };
-
+    console.log('info:::::', userInfo, userProfile);
     await getAllSharedGoogleDocs(authSig, userProfile.idOnService);
   }
 };

--- a/src/utils/litProtocol.js
+++ b/src/utils/litProtocol.js
@@ -33,7 +33,7 @@ export const loadStoredAuthSig = () => {
   return JSON.parse(localStorage.getItem(AUTH_SIG_STORAGE_KEY));
 };
 
-export const googleLitSignOut = () => {
+export const deleteStoredAuthSig = () => {
   return localStorage.removeItem(AUTH_SIG_STORAGE_KEY);
 };
 
@@ -120,6 +120,23 @@ export const getUserProfile = async authSig => {
   try {
     // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L172-L194
     const response = await fetch(`${LIT_API_HOST}/api/google/getUserProfile`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ authSig }),
+    });
+
+    return response.json();
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
+export const signOutUser = async authSig => {
+  try {
+    // https://github.com/LIT-Protocol/lit-oauth/blob/51b6efc4c45ee6b0bf0ebfed4f8713c6c045b954/server/oauth/google.js#L381
+    const response = await fetch(`${LIT_API_HOST}/api/google/signOutUser`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -17520,6 +17520,14 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
@@ -18340,7 +18348,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -22217,6 +22225,13 @@ util@0.10.3:
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 util@^0.11.0:
   version "0.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,6 +2227,110 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cosmjs/amino@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.27.1.tgz#0910256b5aecd794420bb5f7319d98fc63252fa1"
+  integrity sha512-w56ar/nK9+qlvWDpBPRmD0Blk2wfkkLqRi1COs1x7Ll1LF0AtkIBUjbRKplENLbNovK0T3h+w8bHiFm+GBGQOA==
+  dependencies:
+    "@cosmjs/crypto" "0.27.1"
+    "@cosmjs/encoding" "0.27.1"
+    "@cosmjs/math" "0.27.1"
+    "@cosmjs/utils" "0.27.1"
+
+"@cosmjs/amino@^0.28.4":
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.28.7.tgz#1dbfd6b426b4676280aacc1902ff3c732bafd148"
+  integrity sha512-NTCUS3+u9bxwW8moC0N1RS4Gk/fs3JPHTKcp7ksH39V4+7uOKM2rGsyFAekiHNxYngnQ+1hU5x2tddS25soK6Q==
+  dependencies:
+    "@cosmjs/crypto" "0.28.7"
+    "@cosmjs/encoding" "0.28.7"
+    "@cosmjs/math" "0.28.7"
+    "@cosmjs/utils" "0.28.7"
+
+"@cosmjs/crypto@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.27.1.tgz#271c853089a3baf3acd6cf0b2122fd49f8815743"
+  integrity sha512-vbcxwSt99tIYJg8Spp00wc3zx72qx+pY3ozGuBN8gAvySnagK9dQ/jHwtWQWdammmdD6oW+75WfIHZ+gNa+Ybg==
+  dependencies:
+    "@cosmjs/encoding" "0.27.1"
+    "@cosmjs/math" "0.27.1"
+    "@cosmjs/utils" "0.27.1"
+    bip39 "^3.0.2"
+    bn.js "^5.2.0"
+    elliptic "^6.5.3"
+    js-sha3 "^0.8.0"
+    libsodium-wrappers "^0.7.6"
+    ripemd160 "^2.0.2"
+    sha.js "^2.4.11"
+
+"@cosmjs/crypto@0.28.7":
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.28.7.tgz#546dd66234c9a10a67f7b490291283694fbdd8be"
+  integrity sha512-Fuq90nnqXQb6VvUadGtPy1X6arXY+yhqB95VzN8GM/ZdBLeigu6a3XjOvFki4lKO94QdLn2e9huD8dm4tDQDsA==
+  dependencies:
+    "@cosmjs/encoding" "0.28.7"
+    "@cosmjs/math" "0.28.7"
+    "@cosmjs/utils" "0.28.7"
+    "@noble/hashes" "^1"
+    bn.js "^5.2.0"
+    elliptic "^6.5.3"
+    libsodium-wrappers "^0.7.6"
+
+"@cosmjs/encoding@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.27.1.tgz#3cd5bc0af743485eb2578cdb08cfa84c86d610e1"
+  integrity sha512-rayLsA0ojHeniaRfWWcqSsrE/T1rl1gl0OXVNtXlPwLJifKBeLEefGbOUiAQaT0wgJ8VNGBazVtAZBpJidfDhw==
+  dependencies:
+    base64-js "^1.3.0"
+    bech32 "^1.1.4"
+    readonly-date "^1.0.0"
+
+"@cosmjs/encoding@0.28.7":
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.28.7.tgz#7f04a782a558d5116ba61a5441a485be95684b79"
+  integrity sha512-m2OuRhxux0YacvtjTocEOHyjnKO/KKGjqXlAY5HXGJpyntr+PIlJFdoS9tHax+1rNRrblZXwYIT+UqOs+kSk5Q==
+  dependencies:
+    base64-js "^1.3.0"
+    bech32 "^1.1.4"
+    readonly-date "^1.0.0"
+
+"@cosmjs/launchpad@^0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@cosmjs/launchpad/-/launchpad-0.27.1.tgz#b6f1995748be96560f5f01e84d3ff907477dda77"
+  integrity sha512-DcFwGD/z5PK8CzO2sojDxa+Be9EIEtRZb2YawgVnw2Ht/p5FlNv+OVo8qlishpBdalXEN7FvQ1dVeDFEe9TuJw==
+  dependencies:
+    "@cosmjs/amino" "0.27.1"
+    "@cosmjs/crypto" "0.27.1"
+    "@cosmjs/encoding" "0.27.1"
+    "@cosmjs/math" "0.27.1"
+    "@cosmjs/utils" "0.27.1"
+    axios "^0.21.2"
+    fast-deep-equal "^3.1.3"
+
+"@cosmjs/math@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.27.1.tgz#be78857b008ffc6b1ed6fecaa1c4cd5bc38c07d7"
+  integrity sha512-cHWVjmfIjtRc7f80n7x+J5k8pe+vTVTQ0lA82tIxUgqUvgS6rogPP/TmGtTiZ4+NxWxd11DUISY6gVpr18/VNQ==
+  dependencies:
+    bn.js "^5.2.0"
+
+"@cosmjs/math@0.28.7":
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.28.7.tgz#6db91f7dddb364f9d2584817b5fa1bf6b06380c1"
+  integrity sha512-wSXIOOGVzgtRFsGwScpvQ6C6DUx97K7Ez3KyvRALNzspEnIoKPDgTXf438zhZnb+0+ERAwgdkb/6zWaDoVBfUA==
+  dependencies:
+    bn.js "^5.2.0"
+
+"@cosmjs/utils@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.27.1.tgz#1c8efde17256346ef142a3bd15158ee4055470e2"
+  integrity sha512-VG7QPDiMUzVPxRdJahDV8PXxVdnuAHiIuG56hldV4yPnOz/si/DLNd7VAUUA5923b6jS1Hhev0Hr6AhEkcxBMg==
+
+"@cosmjs/utils@0.28.7":
+  version "0.28.7"
+  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.28.7.tgz#d0ac60da967975ac741482a4af5664ff3a0566c2"
+  integrity sha512-0ya5mRaDY956n87dKjx6wfqgH/uEfrZyMswIhcEPqQPegwp4FDd6cwJtSdv/d5S7fgvoEs2UABvUFNzCT5C0hg==
+
 "@craco/craco@^6.3.0":
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-6.4.3.tgz#784395b6ebab764056550a2860494d24c3abd44e"
@@ -2590,6 +2694,21 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/abi@^5.0.1", "@ethersproject/abi@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.3.tgz#2d643544abadf6e6b63150508af43475985c23db"
+  integrity sha512-CxKTdoZY4zDJLWXG6HzNH6znWK0M79WzzxHegDoecE3+K32pzfHOzuXg2/oGSTecZynFgpkjYXNPOqXVJlqClw==
+  dependencies:
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/constants" "^5.6.1"
+    "@ethersproject/hash" "^5.6.1"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.1"
+
 "@ethersproject/abstract-provider@5.5.1", "@ethersproject/abstract-provider@^5.5.0", "@ethersproject/abstract-provider@^5.5.1":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
@@ -2616,6 +2735,19 @@
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/web" "^5.6.0"
 
+"@ethersproject/abstract-provider@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz#02ddce150785caf0c77fe036a0ebfcee61878c59"
+  integrity sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.3"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.2"
+    "@ethersproject/web" "^5.6.1"
+
 "@ethersproject/abstract-signer@5.5.0", "@ethersproject/abstract-signer@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
@@ -2635,6 +2767,17 @@
     "@ethersproject/abstract-provider" "^5.6.0"
     "@ethersproject/bignumber" "^5.6.0"
     "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/abstract-signer@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz#491f07fc2cbd5da258f46ec539664713950b0b33"
+  integrity sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
 
@@ -2660,6 +2803,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/rlp" "^5.6.0"
 
+"@ethersproject/address@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.1.tgz#ab57818d9aefee919c5721d28cd31fd95eff413d"
+  integrity sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.1"
+
 "@ethersproject/base64@5.5.0", "@ethersproject/base64@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
@@ -2673,6 +2827,13 @@
   integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
+
+"@ethersproject/base64@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.1.tgz#2c40d8a0310c9d1606c2c37ae3092634b41d87cb"
+  integrity sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
 
 "@ethersproject/basex@5.5.0", "@ethersproject/basex@^5.5.0":
   version "5.5.0"
@@ -2688,6 +2849,14 @@
   integrity sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
+"@ethersproject/basex@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.6.1.tgz#badbb2f1d4a6f52ce41c9064f01eab19cc4c5305"
+  integrity sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/properties" "^5.6.0"
 
 "@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@^5.0.0", "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.5.0":
@@ -2708,6 +2877,15 @@
     "@ethersproject/logger" "^5.6.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.2.tgz#72a0717d6163fab44c47bcc82e0c550ac0315d66"
+  integrity sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@5.5.0", "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
@@ -2715,7 +2893,7 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
-"@ethersproject/bytes@5.6.1", "@ethersproject/bytes@^5.6.0":
+"@ethersproject/bytes@5.6.1", "@ethersproject/bytes@^5.6.0", "@ethersproject/bytes@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
   integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
@@ -2735,6 +2913,13 @@
   integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
+
+"@ethersproject/constants@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.1.tgz#e2e974cac160dd101cf79fdf879d7d18e8cb1370"
+  integrity sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.2"
 
 "@ethersproject/contracts@5.5.0", "@ethersproject/contracts@^5.5.0":
   version "5.5.0"
@@ -2768,6 +2953,22 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
 
+"@ethersproject/contracts@^5.2.0":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.2.tgz#20b52e69ebc1b74274ff8e3d4e508de971c287bc"
+  integrity sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==
+  dependencies:
+    "@ethersproject/abi" "^5.6.3"
+    "@ethersproject/abstract-provider" "^5.6.1"
+    "@ethersproject/abstract-signer" "^5.6.2"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/constants" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.2"
+
 "@ethersproject/hash@5.5.0", "@ethersproject/hash@^5.0.4", "@ethersproject/hash@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
@@ -2795,6 +2996,20 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/hash@^5.4.0", "@ethersproject/hash@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.1.tgz#224572ea4de257f05b4abf8ae58b03a67e99b0f4"
+  integrity sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.2"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.1"
 
 "@ethersproject/hdnode@5.5.0", "@ethersproject/hdnode@^5.5.0":
   version "5.5.0"
@@ -2831,6 +3046,24 @@
     "@ethersproject/strings" "^5.6.0"
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/wordlists" "^5.6.0"
+
+"@ethersproject/hdnode@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.6.2.tgz#26f3c83a3e8f1b7985c15d1db50dc2903418b2d2"
+  integrity sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.2"
+    "@ethersproject/basex" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.1"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.1"
+    "@ethersproject/signing-key" "^5.6.2"
+    "@ethersproject/strings" "^5.6.1"
+    "@ethersproject/transactions" "^5.6.2"
+    "@ethersproject/wordlists" "^5.6.1"
 
 "@ethersproject/json-wallets@5.5.0", "@ethersproject/json-wallets@^5.5.0":
   version "5.5.0"
@@ -2870,6 +3103,25 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/json-wallets@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz#3f06ba555c9c0d7da46756a12ac53483fe18dd91"
+  integrity sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.2"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/hdnode" "^5.6.2"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.1"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.1"
+    "@ethersproject/strings" "^5.6.1"
+    "@ethersproject/transactions" "^5.6.2"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
 "@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
@@ -2884,6 +3136,14 @@
   integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
+    js-sha3 "0.8.0"
+
+"@ethersproject/keccak256@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.1.tgz#b867167c9b50ba1b1a92bccdd4f2d6bd168a91cc"
+  integrity sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
     js-sha3 "0.8.0"
 
 "@ethersproject/logger@5.5.0", "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.5.0":
@@ -2910,6 +3170,13 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/networks@^5.6.3":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.3.tgz#3ee3ab08f315b433b50c99702eb32e0cf31f899f"
+  integrity sha512-QZxRH7cA5Ut9TbXwZFiCyuPchdWi87ZtVNHWZd0R6YFgYtes2jQ3+bsslJ0WdyDe0i6QumqtoYqvY3rrQFRZOQ==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/pbkdf2@5.5.0", "@ethersproject/pbkdf2@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz#e25032cdf02f31505d47afbf9c3e000d95c4a050"
@@ -2925,6 +3192,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/sha2" "^5.6.0"
+
+"@ethersproject/pbkdf2@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz#f462fe320b22c0d6b1d72a9920a3963b09eb82d1"
+  integrity sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/sha2" "^5.6.1"
 
 "@ethersproject/properties@5.5.0", "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.5.0":
   version "5.5.0"
@@ -2990,6 +3265,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@^5.2.0":
+  version "5.6.8"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.8.tgz#22e6c57be215ba5545d3a46cf759d265bb4e879d"
+  integrity sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.1"
+    "@ethersproject/abstract-signer" "^5.6.2"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/base64" "^5.6.1"
+    "@ethersproject/basex" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/constants" "^5.6.1"
+    "@ethersproject/hash" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.3"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.1"
+    "@ethersproject/rlp" "^5.6.1"
+    "@ethersproject/sha2" "^5.6.1"
+    "@ethersproject/strings" "^5.6.1"
+    "@ethersproject/transactions" "^5.6.2"
+    "@ethersproject/web" "^5.6.1"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.5.1", "@ethersproject/random@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.1.tgz#7cdf38ea93dc0b1ed1d8e480ccdaf3535c555415"
@@ -3004,6 +3305,14 @@
   integrity sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/random@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.1.tgz#66915943981bcd3e11bbd43733f5c3ba5a790255"
+  integrity sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/rlp@5.5.0", "@ethersproject/rlp@^5.5.0":
@@ -3022,6 +3331,14 @@
     "@ethersproject/bytes" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/rlp@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.1.tgz#df8311e6f9f24dcb03d59a2bac457a28a4fe2bd8"
+  integrity sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/sha2@5.5.0", "@ethersproject/sha2@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
@@ -3037,6 +3354,15 @@
   integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
   dependencies:
     "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.1.tgz#211f14d3f5da5301c8972a8827770b6fd3e51656"
+  integrity sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
     hash.js "1.1.7"
 
@@ -3061,6 +3387,18 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.2.tgz#8a51b111e4d62e5a62aee1da1e088d12de0614a3"
+  integrity sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
 
@@ -3106,6 +3444,15 @@
     "@ethersproject/constants" "^5.6.0"
     "@ethersproject/logger" "^5.6.0"
 
+"@ethersproject/strings@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.1.tgz#dbc1b7f901db822b5cafd4ebf01ca93c373f8952"
+  integrity sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/constants" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
@@ -3136,6 +3483,21 @@
     "@ethersproject/rlp" "^5.6.0"
     "@ethersproject/signing-key" "^5.6.0"
 
+"@ethersproject/transactions@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.2.tgz#793a774c01ced9fe7073985bb95a4b4e57a6370b"
+  integrity sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==
+  dependencies:
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/constants" "^5.6.1"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.1"
+    "@ethersproject/signing-key" "^5.6.2"
+
 "@ethersproject/units@5.5.0", "@ethersproject/units@^5.0.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.5.0.tgz#104d02db5b5dc42cc672cc4587bafb87a95ee45e"
@@ -3152,6 +3514,15 @@
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
     "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/units@^5.4.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.1.tgz#ecc590d16d37c8f9ef4e89e2005bda7ddc6a4e6f"
+  integrity sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/constants" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/wallet@5.5.0":
@@ -3196,6 +3567,27 @@
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/wordlists" "^5.6.0"
 
+"@ethersproject/wallet@^5.2.0":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.2.tgz#cd61429d1e934681e413f4bc847a5f2f87e3a03c"
+  integrity sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.1"
+    "@ethersproject/abstract-signer" "^5.6.2"
+    "@ethersproject/address" "^5.6.1"
+    "@ethersproject/bignumber" "^5.6.2"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/hash" "^5.6.1"
+    "@ethersproject/hdnode" "^5.6.2"
+    "@ethersproject/json-wallets" "^5.6.1"
+    "@ethersproject/keccak256" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.1"
+    "@ethersproject/signing-key" "^5.6.2"
+    "@ethersproject/transactions" "^5.6.2"
+    "@ethersproject/wordlists" "^5.6.1"
+
 "@ethersproject/wallet@^5.5.0":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.1.tgz#5df4f75f848ed84ca30fd6ca75d2c66b19c5552b"
@@ -3239,6 +3631,17 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@ethersproject/web@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.1.tgz#6e2bd3ebadd033e6fe57d072db2b69ad2c9bdf5d"
+  integrity sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==
+  dependencies:
+    "@ethersproject/base64" "^5.6.1"
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.1"
+
 "@ethersproject/wordlists@5.5.0", "@ethersproject/wordlists@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
@@ -3260,6 +3663,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/wordlists@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.1.tgz#1e78e2740a8a21e9e99947e47979d72e130aeda1"
+  integrity sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@ethersproject/hash" "^5.6.1"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.1"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -3667,6 +4081,31 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@json-rpc-tools/provider@^1.5.5":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@json-rpc-tools/provider/-/provider-1.7.6.tgz#8a17c34c493fa892632e278fd9331104e8491ec6"
+  integrity sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==
+  dependencies:
+    "@json-rpc-tools/utils" "^1.7.6"
+    axios "^0.21.0"
+    safe-json-utils "^1.1.1"
+    ws "^7.4.0"
+
+"@json-rpc-tools/types@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@json-rpc-tools/types/-/types-1.7.6.tgz#5abd5fde01364a130c46093b501715bcce5bdc0e"
+  integrity sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==
+  dependencies:
+    keyvaluestorage-interface "^1.0.0"
+
+"@json-rpc-tools/utils@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@json-rpc-tools/utils/-/utils-1.7.6.tgz#67f04987dbaa2e7adb6adff1575367b75a9a9ba1"
+  integrity sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==
+  dependencies:
+    "@json-rpc-tools/types" "^1.7.6"
+    "@pedrouid/environment" "^1.0.1"
+
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -3756,6 +4195,11 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@noble/hashes@^1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.1.tgz#c056d9b7166c1e7387a7453c2aff199bf7d88e5f"
+  integrity sha512-Lkp9+NijmV7eSVZqiUvt3UCuuHeJpUVmRrvh430gyJjJiuJMqkeHf6/A9lQ/smmbWV/0spDeJscscPzyB4waZg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -3807,6 +4251,11 @@
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+
+"@pedrouid/environment@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pedrouid/environment/-/environment-1.0.1.tgz#858f0f8a057340e0b250398b75ead77d6f4342ec"
+  integrity sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
@@ -3956,6 +4405,13 @@
   integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@spruceid/siwe-parser@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@spruceid/siwe-parser/-/siwe-parser-1.1.3.tgz#0eebe8bbd63c6de89cb44c06b6329b00b305df65"
+  integrity sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==
+  dependencies:
+    apg-js "^4.1.1"
 
 "@stablelib/aead@^1.0.1":
   version "1.0.1"
@@ -5392,6 +5848,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
   integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@types/node@^12.12.6", "@types/node@^12.7.1":
   version "12.20.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
@@ -5791,6 +6252,18 @@
     rehype "~12.0.1"
     rehype-sanitize "~5.0.1"
 
+"@unstoppabledomains/resolution@^7.1.2":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz#f3f0f9d2f36b88bf0a3af92c26731a01e5dba94b"
+  integrity sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==
+  dependencies:
+    "@ethersproject/abi" "^5.0.1"
+    bn.js "^4.4.0"
+    cross-fetch "^3.1.4"
+    elliptic "^6.5.4"
+    js-sha256 "^0.9.0"
+    js-sha3 "^0.8.0"
+
 "@walletconnect/browser-utils@^1.7.4":
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/@walletconnect/browser-utils/-/browser-utils-1.7.4.tgz#54b24842aa454531212b6c4b02901b5b4a0c1fbe"
@@ -5798,6 +6271,17 @@
   dependencies:
     "@walletconnect/safe-json" "1.0.0"
     "@walletconnect/types" "^1.7.4"
+    "@walletconnect/window-getters" "1.0.0"
+    "@walletconnect/window-metadata" "1.0.0"
+    detect-browser "5.2.0"
+
+"@walletconnect/browser-utils@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz#c9e27f69d838442d69ccf53cb38ffc3c554baee2"
+  integrity sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==
+  dependencies:
+    "@walletconnect/safe-json" "1.0.0"
+    "@walletconnect/types" "^1.7.8"
     "@walletconnect/window-getters" "1.0.0"
     "@walletconnect/window-metadata" "1.0.0"
     detect-browser "5.2.0"
@@ -5812,6 +6296,16 @@
     "@walletconnect/types" "^1.7.4"
     "@walletconnect/utils" "^1.7.4"
 
+"@walletconnect/client@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/client/-/client-1.7.8.tgz#62c2d7114e59495d90772ea8033831ceb29c6a78"
+  integrity sha512-pBroM6jZAaUM0SoXJZg5U7aPTiU3ljQAw3Xh/i2pxFDeN/oPKao7husZ5rdxS5xuGSV6YpqqRb0RxW1IeoR2Pg==
+  dependencies:
+    "@walletconnect/core" "^1.7.8"
+    "@walletconnect/iso-crypto" "^1.7.8"
+    "@walletconnect/types" "^1.7.8"
+    "@walletconnect/utils" "^1.7.8"
+
 "@walletconnect/core@^1.7.4":
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-1.7.4.tgz#7378ba2abc160098c5be69901660f2b127412293"
@@ -5820,6 +6314,15 @@
     "@walletconnect/socket-transport" "^1.7.4"
     "@walletconnect/types" "^1.7.4"
     "@walletconnect/utils" "^1.7.4"
+
+"@walletconnect/core@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-1.7.8.tgz#97c52ea7d00126863cd37bf19bd3e87d4f30de1e"
+  integrity sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==
+  dependencies:
+    "@walletconnect/socket-transport" "^1.7.8"
+    "@walletconnect/types" "^1.7.8"
+    "@walletconnect/utils" "^1.7.8"
 
 "@walletconnect/crypto@^1.0.1":
   version "1.0.1"
@@ -5832,6 +6335,17 @@
     aes-js "^3.1.2"
     hash.js "^1.1.7"
 
+"@walletconnect/crypto@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/crypto/-/crypto-1.0.2.tgz#3fcc2b2cde6f529a19eadd883dc555cd0e861992"
+  integrity sha512-+OlNtwieUqVcOpFTvLBvH+9J9pntEqH5evpINHfVxff1XIgwV55PpbdvkHu6r9Ib4WQDOFiD8OeeXs1vHw7xKQ==
+  dependencies:
+    "@walletconnect/encoding" "^1.0.1"
+    "@walletconnect/environment" "^1.0.0"
+    "@walletconnect/randombytes" "^1.0.2"
+    aes-js "^3.1.2"
+    hash.js "^1.1.7"
+
 "@walletconnect/encoding@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/encoding/-/encoding-1.0.0.tgz#e24190cb5e803526f9dfd7191fb0e4dc53c6d864"
@@ -5840,10 +6354,32 @@
     is-typedarray "1.0.0"
     typedarray-to-buffer "3.1.5"
 
+"@walletconnect/encoding@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/encoding/-/encoding-1.0.1.tgz#93c18ce9478c3d5283dbb88c41eb2864b575269a"
+  integrity sha512-8opL2rs6N6E3tJfsqwS82aZQDL3gmupWUgmvuZ3CGU7z/InZs3R9jkzH8wmYtpbq0sFK3WkJkQRZFFk4BkrmFA==
+  dependencies:
+    is-typedarray "1.0.0"
+    typedarray-to-buffer "3.1.5"
+
 "@walletconnect/environment@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/environment/-/environment-1.0.0.tgz#c4545869fa9c389ec88c364e1a5f8178e8ab5034"
   integrity sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ==
+
+"@walletconnect/ethereum-provider@^1.7.5":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-1.7.8.tgz#8b969b394e14c68855b6ae2660f2e39dec857f5f"
+  integrity sha512-dnl560zFMdK/LD4MD2XwHbWj7RXOaeXWPc9jzDaosLQLAXfA5mKe4XbCFFUPbVMYuyBdRI9NZv3Ci/qDb5wncQ==
+  dependencies:
+    "@walletconnect/client" "^1.7.8"
+    "@walletconnect/jsonrpc-http-connection" "^1.0.0"
+    "@walletconnect/jsonrpc-provider" "^1.0.3"
+    "@walletconnect/signer-connection" "^1.7.8"
+    "@walletconnect/types" "^1.7.8"
+    "@walletconnect/utils" "^1.7.8"
+    eip1193-provider "1.0.1"
+    eventemitter3 "4.0.7"
 
 "@walletconnect/http-connection@^1.7.4":
   version "1.7.4"
@@ -5864,10 +6400,43 @@
     "@walletconnect/types" "^1.7.4"
     "@walletconnect/utils" "^1.7.4"
 
+"@walletconnect/iso-crypto@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz#41f09326d129faa09beae213e78614c19d90bbd6"
+  integrity sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==
+  dependencies:
+    "@walletconnect/crypto" "^1.0.2"
+    "@walletconnect/types" "^1.7.8"
+    "@walletconnect/utils" "^1.7.8"
+
+"@walletconnect/jsonrpc-http-connection@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.2.tgz#765daf7ce3c460ed4ac38d3f086b40b285cc2f5e"
+  integrity sha512-QBewWf38vHLLnZndxHkmO2dfJr78KR0d7KHdKt8SkKlqTML423fU8zkKM5gAnVviyn8J5ytyus6nyECK84i+Qg==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.3"
+    "@walletconnect/safe-json" "^1.0.0"
+    cross-fetch "^3.1.4"
+
+"@walletconnect/jsonrpc-provider@^1.0.3":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.5.tgz#1a66053b6f083a9885a32b7c2c8f6a376f1a4458"
+  integrity sha512-v61u4ZIV8+p9uIHS2Kl2YRj/2idrQiHcrbrJXw3McQkEJtj9mkCofr1Hu/n419wSRM5uiNK8Z4WRS9zGTTAhWQ==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.3"
+    "@walletconnect/safe-json" "^1.0.0"
+
 "@walletconnect/jsonrpc-types@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.0.tgz#fa75ad5e8f106a2e33287b1e6833e22ed0225055"
   integrity sha512-11QXNq5H1PKZk7bP8SxgmCw3HRaDuPOVE+wObqEvmhc7OWYUZqfuaaMb+OXGRSOHL3sbC+XHfdeCxFTMXSFyng==
+  dependencies:
+    keyvaluestorage-interface "^1.0.0"
+
+"@walletconnect/jsonrpc-types@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.1.tgz#a96b4bb2bcc8838a70e06f15c1b5ab11c47d8e95"
+  integrity sha512-+6coTtOuChCqM+AoYyi4Q83p9l/laI6NvuM2/AHaZFuf0gT0NjW7IX2+86qGyizn7Ptq4AYZmfxurAxTnhefuw==
   dependencies:
     keyvaluestorage-interface "^1.0.0"
 
@@ -5878,6 +6447,14 @@
   dependencies:
     "@walletconnect/environment" "^1.0.0"
     "@walletconnect/jsonrpc-types" "^1.0.0"
+
+"@walletconnect/jsonrpc-utils@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.3.tgz#5bd49865eef0eae48e8b45a06731dc18691cf8c7"
+  integrity sha512-3yb49bPk16MNLk6uIIHPSHQCpD6UAo1OMOx1rM8cW/MPEAYAzrSW5hkhG7NEUwX9SokRIgnZK3QuQkiyNzBMhQ==
+  dependencies:
+    "@walletconnect/environment" "^1.0.0"
+    "@walletconnect/jsonrpc-types" "^1.0.1"
 
 "@walletconnect/mobile-registry@^1.4.0":
   version "1.4.0"
@@ -5896,6 +6473,18 @@
     preact "10.4.1"
     qrcode "1.4.4"
 
+"@walletconnect/qrcode-modal@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/qrcode-modal/-/qrcode-modal-1.7.8.tgz#52b3d15922f3e371ddc92fd0f49f93ff40241365"
+  integrity sha512-LqNJMLWO+ljvoRSdq8tcEslW0imKrrb+ugs3bw4w/jEI1FSJzVeinEsgVpyaMv8wsUcyTcSCXSkXpT1SXHtcpw==
+  dependencies:
+    "@walletconnect/browser-utils" "^1.7.8"
+    "@walletconnect/mobile-registry" "^1.4.0"
+    "@walletconnect/types" "^1.7.8"
+    copy-to-clipboard "^3.3.1"
+    preact "10.4.1"
+    qrcode "1.4.4"
+
 "@walletconnect/randombytes@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/randombytes/-/randombytes-1.0.1.tgz#87f0f02d9206704ce1c9e23f07d3b28898c48385"
@@ -5905,10 +6494,31 @@
     "@walletconnect/environment" "^1.0.0"
     randombytes "^2.1.0"
 
-"@walletconnect/safe-json@1.0.0":
+"@walletconnect/randombytes@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/randombytes/-/randombytes-1.0.2.tgz#95c644251a15e6675f58fbffc9513a01486da49c"
+  integrity sha512-ivgOtAyqQnN0rLQmOFPemsgYGysd/ooLfaDA/ACQ3cyqlca56t3rZc7pXfqJOIETx/wSyoF5XbwL+BqYodw27A==
+  dependencies:
+    "@walletconnect/encoding" "^1.0.1"
+    "@walletconnect/environment" "^1.0.0"
+    randombytes "^2.1.0"
+
+"@walletconnect/safe-json@1.0.0", "@walletconnect/safe-json@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/safe-json/-/safe-json-1.0.0.tgz#12eeb11d43795199c045fafde97e3c91646683b2"
   integrity sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg==
+
+"@walletconnect/signer-connection@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/signer-connection/-/signer-connection-1.7.8.tgz#07453ce25ef7c657c051b74fe1b48e72e2ebc459"
+  integrity sha512-H+kps4XqabiOQzG/FEgXSjEUlZLQ7Iz9pnNLtuC1Vr+9fvjq9sEkCPBH89N7QL+MDh6q8dU2sADEZzyqNEY6dg==
+  dependencies:
+    "@walletconnect/client" "^1.7.8"
+    "@walletconnect/jsonrpc-types" "^1.0.0"
+    "@walletconnect/jsonrpc-utils" "^1.0.0"
+    "@walletconnect/qrcode-modal" "^1.7.8"
+    "@walletconnect/types" "^1.7.8"
+    eventemitter3 "4.0.7"
 
 "@walletconnect/socket-transport@^1.7.4":
   version "1.7.4"
@@ -5919,10 +6529,24 @@
     "@walletconnect/utils" "^1.7.4"
     ws "7.5.3"
 
+"@walletconnect/socket-transport@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz#a4ef50d8054293991dbfde7f9c66788030182ec3"
+  integrity sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==
+  dependencies:
+    "@walletconnect/types" "^1.7.8"
+    "@walletconnect/utils" "^1.7.8"
+    ws "7.5.3"
+
 "@walletconnect/types@^1.7.4":
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.7.4.tgz#429c0ab88771ca39f085757c189ffc704acaf813"
   integrity sha512-jvdW1/7z16dCC3i2uwPSgXjUXkmvJH0M2PbYD8ZETyEj/oSiLd32nPAUZVU0IVqQk4XAZHUTKhlRgxTch1W4Qg==
+
+"@walletconnect/types@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.7.8.tgz#ec397e6fbdc8147bccc17029edfeb41c50a5ca09"
+  integrity sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA==
 
 "@walletconnect/utils@^1.7.4":
   version "1.7.4"
@@ -5933,6 +6557,19 @@
     "@walletconnect/encoding" "^1.0.0"
     "@walletconnect/jsonrpc-utils" "^1.0.0"
     "@walletconnect/types" "^1.7.4"
+    bn.js "4.11.8"
+    js-sha3 "0.8.0"
+    query-string "6.13.5"
+
+"@walletconnect/utils@^1.7.8":
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-1.7.8.tgz#f94572bca5eb6b5f81daf8a35268f249f9c6b1ec"
+  integrity sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==
+  dependencies:
+    "@walletconnect/browser-utils" "^1.7.8"
+    "@walletconnect/encoding" "^1.0.1"
+    "@walletconnect/jsonrpc-utils" "^1.0.0"
+    "@walletconnect/types" "^1.7.8"
     bn.js "4.11.8"
     js-sha3 "0.8.0"
     query-string "6.13.5"
@@ -7000,6 +7637,13 @@ axe-core@^4.3.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
+axios@^0.21.0, axios@^0.21.2:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -7286,7 +7930,7 @@ base-x@^3.0.2, base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.0.2, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -7326,7 +7970,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@1.1.4:
+bech32@1.1.4, bech32@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
@@ -7387,10 +8031,25 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bip39@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+
 blakejs@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
   integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
+
+blob-polyfill@^6.0.20211015:
+  version "6.0.20211015"
+  resolved "https://registry.yarnpkg.com/blob-polyfill/-/blob-polyfill-6.0.20211015.tgz#7c47e62347e302e8d1d1ee5e140b881f74bdb23e"
+  integrity sha512-OGL4bm6ZNpdFAvQugRlQy5MNly8gk15aWi/ZhQHimQsrx9WKD05r+v+xNgHCChLER3MH+9KLAhzuFlwFKrH1Yw==
 
 bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.2"
@@ -7412,10 +8071,15 @@ bn.js@5.2.0, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.4.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@1.19.2, body-parser@^1.16.0:
   version "1.19.2"
@@ -7710,7 +8374,15 @@ buffer@^5.0.5, buffer@^5.4.3, buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bufferutil@^4.0.1:
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
+bufferutil@^4.0.1, bufferutil@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.6.tgz#ebd6c67c7922a0e902f053e5d8be5ec850e48433"
   integrity sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==
@@ -8751,6 +9423,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-blob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cross-blob/-/cross-blob-3.0.1.tgz#335127e9b0143083686a7825f93bae9fbc3523a3"
+  integrity sha512-OfDx5IUeufBuN0jFUusyZQckF0ncqXpgA9manQKBQobnb5UYToR+IWEBhabr0KJPAXDFkmqhXwZ5AYHIgFPHpg==
+  dependencies:
+    blob-polyfill "^6.0.20211015"
+    fetch-blob "^3.1.4"
+
 cross-fetch@^2.1.0:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.6.tgz#2ef0bb39a24ac034787965c457368a28730e220a"
@@ -9223,6 +9903,11 @@ dashdash@^1.12.0:
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
+
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
 
 data-urls@^2.0.0:
   version "2.0.0"
@@ -9836,6 +10521,13 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+eip1193-provider@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eip1193-provider/-/eip1193-provider-1.0.1.tgz#420d29cf4f6c443e3f32e718fb16fafb250637c3"
+  integrity sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==
+  dependencies:
+    "@json-rpc-tools/provider" "^1.5.5"
 
 ejs@^3.1.6:
   version "3.1.7"
@@ -11281,6 +11973,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.5.tgz#0077bf5f3fcdbd9d75a0b5362f77dbb743489863"
+  integrity sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -11468,6 +12168,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.12.1:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.0:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -11545,6 +12250,13 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -12816,7 +13528,7 @@ idna-uts46-hx@^2.3.1:
   dependencies:
     punycode "2.1.0"
 
-ieee754@^1.1.13, ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -14318,6 +15030,16 @@ jsprim@^1.2.2:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
+jszip@^3.6.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.0.tgz#faf3db2b4b8515425e34effcdbb086750a346061"
+  integrity sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 junk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
@@ -14522,10 +15244,29 @@ libnpx@^10.2.4:
     y18n "^4.0.0"
     yargs "^14.2.3"
 
+libsodium-wrappers@^0.7.6:
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz#13ced44cacb0fc44d6ac9ce67d725956089ce733"
+  integrity sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==
+  dependencies:
+    libsodium "^0.7.0"
+
+libsodium@^0.7.0:
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.10.tgz#c2429a7e4c0836f879d701fec2c8a208af024159"
+  integrity sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ==
+
 lie@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
   integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
 
@@ -14543,6 +15284,52 @@ listify@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/listify/-/listify-1.0.3.tgz#a9335ac351c3d1aea515494ed746976eeb92248b"
   integrity sha512-083swF7iH7bx8666zdzBColpgEuy46HjN3r1isD4zV6Ix7FuHfb/2/WVnl4CH8hjuoWeFF7P5KkKNXUnJCFEJg==
+
+lit-connect-modal@^0.1.8:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/lit-connect-modal/-/lit-connect-modal-0.1.10.tgz#b9f6008aaa10a19e9accd2bf447853429fbe270c"
+  integrity sha512-hiE/0yrl15EDNH08OqcntiNXDOvU4zviiaOOCT4jG2N3L2dyMFLOwXXrkNobQ6B8/8MgXmMJu2TCp6RwhmCzNw==
+  dependencies:
+    micromodal "^0.4.10"
+
+lit-js-sdk@^1.1.182:
+  version "1.1.182"
+  resolved "https://registry.yarnpkg.com/lit-js-sdk/-/lit-js-sdk-1.1.182.tgz#b151a58070b82a7189aba8a34e3b61dd50319e84"
+  integrity sha512-bax8pXsyFKIYUCbfyWjjfaO/ay+suJoshzJDF6cTq6/MzM4cQqTGf3aI0ZSBH82E6qdX5ddunOiK/T2tp/PfEQ==
+  dependencies:
+    "@cosmjs/amino" "^0.28.4"
+    "@cosmjs/launchpad" "^0.27.1"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/contracts" "^5.2.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/providers" "^5.2.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/units" "^5.4.0"
+    "@ethersproject/wallet" "^5.2.0"
+    "@unstoppabledomains/resolution" "^7.1.2"
+    "@walletconnect/ethereum-provider" "^1.7.5"
+    buffer "^6.0.3"
+    bufferutil "^4.0.6"
+    cross-blob "^3.0.1"
+    jszip "^3.6.0"
+    lit-connect-modal "^0.1.8"
+    lit-siwe "^1.1.8"
+    node-fetch "^3.2.3"
+    pako "^2.0.4"
+    tslib "^2.3.1"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+    uint8arrays "^3.0.0"
+    utf-8-validate "^5.0.8"
+
+lit-siwe@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/lit-siwe/-/lit-siwe-1.1.8.tgz#6a393069012816d629c518bb8aa410f1e4a78bd7"
+  integrity sha512-gXI8GG0GAClw6G7T9p4p6Kn9ywDo8j2d90ShaYArJdsqqO9gwXfzxF84SMeY+bpsNqqQ3FahrhEwTCHd6w7wNw==
+  dependencies:
+    "@spruceid/siwe-parser" "1.1.3"
+    "@stablelib/random" "^1.0.1"
+    apg-js "^4.1.1"
 
 load-script@^1.0.0:
   version "1.0.0"
@@ -15453,6 +16240,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+micromodal@^0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/micromodal/-/micromodal-0.4.10.tgz#d6f59c21d2f4a5af480f65909eb9608a1d558c73"
+  integrity sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ==
+
 middleearth-names@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/middleearth-names/-/middleearth-names-1.1.0.tgz#c1d5ee48defb368128fbaebfebce8847cd18ddff"
@@ -15951,12 +16743,26 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.2.3:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.6.tgz#6d4627181697a9d9674aae0d61548e0d629b31b9"
+  integrity sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^1.2.0:
   version "1.3.0"
@@ -16530,7 +17336,12 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-pako@~1.0.5:
+pako@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
+  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
+
+pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -16709,7 +17520,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pbkdf2@^3.0.17, pbkdf2@^3.0.3:
+pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
   integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
@@ -18468,6 +19279,11 @@ readme-badger@^0.3.0:
   dependencies:
     balanced-match "^1.0.0"
 
+readonly-date@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/readonly-date/-/readonly-date-1.0.0.tgz#5af785464d8c7d7c40b9d738cbde8c646f97dcd9"
+  integrity sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==
+
 recursive-readdir@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
@@ -18990,7 +19806,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@^2.0.0, ripemd160@^2.0.1:
+ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
   integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
@@ -19100,6 +19916,11 @@ safe-event-emitter@^1.0.1:
   integrity sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==
   dependencies:
     events "^3.0.0"
+
+safe-json-utils@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/safe-json-utils/-/safe-json-utils-1.1.1.tgz#0e883874467d95ab914c3f511096b89bfb3e63b1"
+  integrity sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -19412,7 +20233,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.4.0, sha.js@^2.4.8:
+sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -20764,6 +21585,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -20795,7 +21621,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tweetnacl-util@^0.15.0:
+tweetnacl-util@^0.15.0, tweetnacl-util@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
   integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
@@ -21350,6 +22176,13 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
+utf-8-validate@^5.0.8:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.9.tgz#ba16a822fbeedff1a58918f2a6a6b36387493ea3"
+  integrity sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 utf8@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
@@ -21638,6 +22471,11 @@ web-namespaces@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 web-vitals@^0.2.4:
   version "0.2.4"
@@ -22529,6 +23367,11 @@ ws@^5.1.1:
   integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
   dependencies:
     async-limiter "~1.0.0"
+
+ws@^7.4.0:
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a"
+  integrity sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==
 
 ws@^7.4.6:
   version "7.5.7"


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-app/issues/1774

## Changes

- [X] adding install Lit Boost with proper descriptions
- [X] building custom components for Lit integration

adding initial communication with lit protocol:

- [X] sign wallet and pass auth to lit for document interaction
- [X] get shared documents from dao - currently no documents will return because we need to wait for upgrades on Lits server
- [X] receiving response from getAllShares (get all documents) and (getAllDaoShares)

## Packages Added

- lit-protocol-sdk - sdk used for querying and interacting with Lit Protocol
- path - this one is odd, I was getting a weird error around webpack 5 and manually installing node polyfills - adding path fixed this (has something to do with `libsodium` a dependency from lit-protocol-sdk) - see [Details for info](#lit-sdk-errorrs)

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally

## Details

#lit-sdk-errorrs

solved by including `path` in the `package.json`
```
ERROR in ./node_modules/libsodium/dist/modules/libsodium.js 39:23-46
Module not found: Error: Can't resolve 'path' in '/Users/brianrossetti/Projects/current/web3/projects/hausDAO-top/daohaus-app/node_modules/libsodium/dist/modules'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
	- install 'path-browserify'
```

## Follow ups
There are a few interactions with Lit which are causing unintended consequences:

- Lit seems to only allow one account to be connected to an 