### PR TITLE
adding check on proposal status if its passed or failed. May use

### DIFF
--- a/src/components/proposalActions.jsx
+++ b/src/components/proposalActions.jsx
@@ -29,11 +29,7 @@ import MinionCancel from './minionCancel';
 import EscrowActions from './escrowActions';
 
 import { TX } from '../data/txLegos/contractTX';
-import {
-  isMinionProposalType,
-  memberVote,
-  ProposalStatus,
-} from '../utils/proposalUtils';
+import { isMinionProposalType, memberVote } from '../utils/proposalUtils';
 import { getTerm, getTitle } from '../utils/metadata';
 import { capitalize, daoConnectedAndSameChain } from '../utils/general';
 import { createContract } from '../utils/contract';
@@ -311,7 +307,7 @@ const ProposalActions = ({
                   display='flex'
                   flexDirection='row'
                 >
-                  {currentlyVoting(proposal) ? (
+                  {currentlyVoting(proposal) && !proposal?.executed ? (
                     <>
                       {daoConnectedAndSameChain(
                         address,
@@ -330,16 +326,12 @@ const ProposalActions = ({
                               justiy='center'
                               align='center'
                             >
-                              <Button
+                              <Icon
                                 as={FaThumbsUp}
                                 color='green.500'
                                 w='25px'
                                 h='25px'
                                 _hover={{ cursor: 'pointer' }}
-                                disabled={
-                                  proposal?.status === ProposalStatus.Passed ||
-                                  proposal?.status === ProposalStatus.Failed
-                                }
                                 onClick={() => submitVote(proposal, 1)}
                               />
                             </Flex>
@@ -352,17 +344,13 @@ const ProposalActions = ({
                               justiy='center'
                               align='center'
                             >
-                              <Button
+                              <Icon
                                 as={FaThumbsDown}
                                 color='red.500'
                                 w='25px'
                                 h='25px'
                                 transform='rotateY(180deg)'
                                 _hover={{ cursor: 'pointer' }}
-                                disabled={
-                                  proposal?.status === ProposalStatus.Passed ||
-                                  proposal?.status === ProposalStatus.Failed
-                                }
                                 onClick={() => submitVote(proposal, 2)}
                               />
                             </Flex>

--- a/src/components/proposalActions.jsx
+++ b/src/components/proposalActions.jsx
@@ -29,7 +29,11 @@ import MinionCancel from './minionCancel';
 import EscrowActions from './escrowActions';
 
 import { TX } from '../data/txLegos/contractTX';
-import { isMinionProposalType, memberVote } from '../utils/proposalUtils';
+import {
+  isMinionProposalType,
+  memberVote,
+  ProposalStatus,
+} from '../utils/proposalUtils';
 import { getTerm, getTitle } from '../utils/metadata';
 import { capitalize, daoConnectedAndSameChain } from '../utils/general';
 import { createContract } from '../utils/contract';
@@ -326,12 +330,16 @@ const ProposalActions = ({
                               justiy='center'
                               align='center'
                             >
-                              <Icon
+                              <Button
                                 as={FaThumbsUp}
                                 color='green.500'
                                 w='25px'
                                 h='25px'
                                 _hover={{ cursor: 'pointer' }}
+                                disabled={
+                                  proposal?.status === ProposalStatus.Passed ||
+                                  proposal?.status === ProposalStatus.Failed
+                                }
                                 onClick={() => submitVote(proposal, 1)}
                               />
                             </Flex>
@@ -344,13 +352,17 @@ const ProposalActions = ({
                               justiy='center'
                               align='center'
                             >
-                              <Icon
+                              <Button
                                 as={FaThumbsDown}
                                 color='red.500'
                                 w='25px'
                                 h='25px'
                                 transform='rotateY(180deg)'
                                 _hover={{ cursor: 'pointer' }}
+                                disabled={
+                                  proposal?.status === ProposalStatus.Passed ||
+                                  proposal?.status === ProposalStatus.Failed
+                                }
                                 onClick={() => submitVote(proposal, 2)}
                               />
                             </Flex>


### PR DESCRIPTION
ReadyForProcessing as well.

## GitHub Issue

https://github.com/HausDAO/daohaus-app/issues/1917

## Changes

adding a check on `proposal.status` to make sure its not `ProposalStatus.Passed` or `ProposalStatus.Failed`

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
