### PR TITLE
fix decoding issues for deprecated minions

### DIFF
--- a/src/utils/minionUtils.js
+++ b/src/utils/minionUtils.js
@@ -208,7 +208,7 @@ export const getMinionAction = async params => {
     safeMinionVersion,
   } = params;
 
-  const abi = getMinionAbi(minionType, safeMinionVersion);
+  const abi = getMinionAbi(minionType, safeMinionVersion || '1');
   const actionName =
     MINION_ACTION_FUNCTION_NAMES[minionType] ||
     MINION_ACTION_FUNCTION_NAMES[proposalType];


### PR DESCRIPTION
## GitHub Issue

#1915

## Changes

Handle proposal decoding for cases where a DAO is using a deprecated minion (safeMinionVersion: null)

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
