### PR TITLE
adding checks on quorum to get rid of tooltip when quorum is met

### DIFF
--- a/src/proposalBuilder/executeQuorum.jsx
+++ b/src/proposalBuilder/executeQuorum.jsx
@@ -36,16 +36,24 @@ export const ExecuteQuorum = ({ proposal, voteData }) => {
     });
   };
 
+  const Quorum = color => (
+    <>
+      <BiTachometer color={color} size='1.2rem' />
+      <ParaSm ml={1}>
+        {percYesVotes}/{proposal.minion.minQuorum}%
+      </ParaSm>
+    </>
+  );
+
   if (!proposal?.minion?.minQuorum || !earlyExecuteMinionType(proposal))
     return null;
-  if (hasReachedQuorum && !proposal.executed) {
-    return (
+  if (hasReachedQuorum) {
+    return !proposal.executed ? (
       <Button variant='ghost' size='fit-content' onClick={execute} p='0'>
-        <BiTachometer color={theme?.colors?.secondary?.[500]} size='1.2rem' />
-        <ParaSm ml={1}>
-          {percYesVotes}/{proposal.minion.minQuorum}%
-        </ParaSm>
+        <Quorum color={theme?.colors?.secondary?.[500]} />
       </Button>
+    ) : (
+      <Quorum color={theme?.colors?.secondary?.[500]} />
     );
   }
 
@@ -62,10 +70,7 @@ export const ExecuteQuorum = ({ proposal, voteData }) => {
         }}
       >
         <Flex alignItems='center'>
-          <BiTachometer color='white' size='1.2rem' />
-          <ParaSm ml={1}>
-            {percYesVotes}/{proposal.minion.minQuorum}%
-          </ParaSm>
+          <Quorum color='white' />
         </Flex>
       </ToolTipWrapper>
     </Flex>

--- a/src/proposalBuilder/executeQuorum.jsx
+++ b/src/proposalBuilder/executeQuorum.jsx
@@ -37,12 +37,12 @@ export const ExecuteQuorum = ({ proposal, voteData }) => {
   };
 
   const Quorum = color => (
-    <>
+    <Flex alignItems='center'>
       <BiTachometer color={color} size='1.2rem' />
       <ParaSm ml={1}>
         {percYesVotes}/{proposal.minion.minQuorum}%
       </ParaSm>
-    </>
+    </Flex>
   );
 
   if (!proposal?.minion?.minQuorum || !earlyExecuteMinionType(proposal))
@@ -69,9 +69,7 @@ export const ExecuteQuorum = ({ proposal, voteData }) => {
           ],
         }}
       >
-        <Flex alignItems='center'>
-          <Quorum color='white' />
-        </Flex>
+        <Quorum color='white' />
       </ToolTipWrapper>
     </Flex>
   );


### PR DESCRIPTION
## GitHub Issue

[Add a link to the GitHub issue.](https://github.com/HausDAO/daohaus-app/issues/1918)

## Changes

splitting up check to add quorum vs proposal executed so that we do not display the tooltip after quorum is met.

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally

images show before and after making the changes.

<img width="461" alt="Screen Shot 2022-06-30 at 1 36 56 PM" src="https://user-images.githubusercontent.com/5998100/176763389-40ce308a-83a0-430c-84d0-868fed1790dd.png">
<img width="330" alt="Screen Shot 2022-06-30 at 1 37 17 PM" src="https://user-images.githubusercontent.com/5998100/176763397-2e18df70-1f4f-4468-ae7b-9d9a40740ad5.png">
