### PR TITLE
adding await to response so error can be interpreted; ensuring a chec…

### DIFF
--- a/src/components/activityCard.jsx
+++ b/src/components/activityCard.jsx
@@ -57,7 +57,7 @@ const ActivityCard = ({ activity, displayAvatar, isLink = true }) => {
     const getProfile = async () => {
       try {
         const newProfile = await handleGetProfile(activity.memberAddress);
-        if (newProfile.status === 'error') {
+        if (!newProfile) {
           setProfile(null);
           return;
         }

--- a/src/components/hubProfileCard.jsx
+++ b/src/components/hubProfileCard.jsx
@@ -15,7 +15,7 @@ const HubProfileCard = ({ address }) => {
       if (address) {
         try {
           const data = await handleGetProfile(address);
-          if (data.status === 'error') {
+          if (!data) {
             return;
           }
           setProfile(data);

--- a/src/formBuilder/addressInput.jsx
+++ b/src/formBuilder/addressInput.jsx
@@ -37,7 +37,7 @@ const AddressInput = props => {
       const memberProfiles = await Promise.all(
         getActiveMembers(daoMembers)?.map(async member => {
           const profile = await handleGetProfile(member.memberAddress);
-          if (profile?.status !== 'error') {
+          if (!profile) {
             return {
               name: profile.name || truncateAddr(member.memberAddress),
               value: member.memberAddress,

--- a/src/utils/3box.js
+++ b/src/utils/3box.js
@@ -53,12 +53,14 @@ const get3boxProfile = async address => {
     const response = await fetch(
       `https://ipfs.3box.io/profile?address=${address}`,
     );
-    if (response.status === 'error') {
+
+    if (response.status === 'error' || response.status === 404) {
       console.warn('Profile does not exist');
+      return null;
     }
 
-    const boxProfile = response.json();
-    return boxProfile;
+    // boxProfile
+    return await response.json();
   } catch (error) {
     console.warn(error);
   }


### PR DESCRIPTION
…k for profile on several calls

## GitHub Issue

fixes https://github.com/HausDAO/daohaus-app/issues/1919

## Changes

- [X] adding an await call on `response.json()` so the response can be interpreted correctly
- [X] ensuring that responses check for `null` before proceeding (several places where 3box fetch is used)

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally

# Details

<img width="450" alt="Screen Shot 2022-07-05 at 3 26 40 PM" src="https://user-images.githubusercontent.com/5998100/177420568-f9c954f7-b07b-421c-9ec5-dcebadbc8162.png">
