### PR TITLE
optional chaining added to avoid crash if no nft image or ext_url

### DIFF
--- a/src/modals/nftViewModal.jsx
+++ b/src/modals/nftViewModal.jsx
@@ -140,10 +140,10 @@ const NftViewModal = () => {
                         </Box>
                       )}
                     </Flex>
-                    {nftViewModal.name && nftViewModal.metadata.external_url && (
+                    {nftViewModal.name && nftViewModal.metadata?.external_url && (
                       <Box
                         as={Link}
-                        href={nftViewModal.metadata.external_url}
+                        href={nftViewModal.metadata?.external_url}
                         isExternal
                         size='xl'
                         color='secondary.500'

--- a/src/utils/nftData.js
+++ b/src/utils/nftData.js
@@ -171,7 +171,7 @@ export const attributeModifiers = Object.freeze({
     return description.split(' ')[4];
   },
   hydrateImageURI(nft) {
-    if (nft.image.match(/^ipfs:\/\/(Qm[a-zA-Z0-9]+)/)) {
+    if (nft.image?.match(/^ipfs:\/\/(Qm[a-zA-Z0-9]+)/)) {
       return `https://daohaus.mypinata.cloud/ipfs/${
         nft.image.match(/^ipfs:\/\/(Qm[a-zA-Z0-9]+)/)[1]
       }`;


### PR DESCRIPTION
## GitHub Issue

https://github.com/HausDAO/daohaus-app/issues/1962

## Changes

Does not crash anymore if `nft` does not have an `image` property or `nftViewModal` metadata does not have an `external_url` property

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs and builds locally
