### PR TITLE
fix fetching modules from gnosis safe v1.1.1

### DIFF
--- a/src/components/safeMinionDetails.jsx
+++ b/src/components/safeMinionDetails.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { RiErrorWarningLine } from 'react-icons/ri';
+import { RiErrorWarningLine, RiExternalLinkLine } from 'react-icons/ri';
 import { TiWarningOutline } from 'react-icons/ti';
 import Icon from '@chakra-ui/icon';
-import { Box, Flex, Text } from '@chakra-ui/layout';
+import { Box, Flex, Link, Text } from '@chakra-ui/layout';
 import { Button } from '@chakra-ui/react';
 import { utils as Web3Utils } from 'web3';
 import ModuleManager from '@gnosis.pm/safe-contracts/build/artifacts/contracts/base/ModuleManager.sol/ModuleManager.json';
@@ -82,6 +82,8 @@ const SafeMinionDetails = ({
   const { address, injectedChain, injectedProvider } = useInjectedProvider();
   const { successToast, errorToast } = useOverlay();
   const { submitTransaction } = useTX();
+
+  const chainConfig = chainByID(daochain);
 
   useEffect(() => {
     if (daoOverview) {
@@ -383,6 +385,26 @@ const SafeMinionDetails = ({
             />
           )}
         </Flex>
+        {safeDetails?.gnosisSafeVersion?.split('.')[1] < 3 && (
+          <Text fontSize='xs' mt={4}>
+            ** Your Gnosis Safe version is {safeDetails.gnosisSafeVersion}.
+            Please consider upgrading it to a newer version.
+            <Link
+              href={`https://gnosis-safe.io/app/${chainConfig.shortNamePrefix ||
+                chainConfig.short_name}:${
+                safeDetails.address
+              }/settings/details`}
+              isExternal
+            >
+              <Icon
+                as={RiExternalLinkLine}
+                name='explorer link'
+                color='secondary.300'
+                _hover={{ cursor: 'pointer' }}
+              />
+            </Link>
+          </Text>
+        )}
         {safeMinionVersion && safeMinionVersion === '1' && (
           <Text fontSize='xs' mt={4}>
             ** This is a early version of the Safe Minion. It might not work in

--- a/src/utils/gnosis.js
+++ b/src/utils/gnosis.js
@@ -149,6 +149,7 @@ export const fetchSafeDetails = async ({
     ambModuleAddress:
       ambController &&
       (await fetchAmbModule(ambController, chainID, safeAddress)),
+    gnosisSafeVersion: await safeSdk.getContractVersion(),
   };
 };
 

--- a/src/utils/gnosis.js
+++ b/src/utils/gnosis.js
@@ -40,6 +40,7 @@ export const getSafe = async ({
   injectedProvider,
   safeAddress,
   signerAddress,
+  patchV1,
 }) => {
   try {
     const rpcUrl = chainByID(chainID).rpc_url;
@@ -49,11 +50,11 @@ export const getSafe = async ({
       web3,
       signerAddress,
     });
-    // TODO: Workaround when dealing with GnosisSafe w/version < 1.3.0
+    // Workaround when dealing with GnosisSafe w/version < 1.3.0
     // == BEGIN
     const networkChainId = (await ethAdapter.getChainId()).toString();
     const deployment = getSafeSingletonDeployment({
-      version: '1.3.0',
+      version: patchV1 ? '1.1.1' : '1.3.0',
       network: networkChainId,
       released: true,
     });
@@ -80,10 +81,15 @@ export const getSafe = async ({
 const isModuleEnabledInternal = async (safeSdk, moduleAddress) => {
   const v = await safeSdk.getContractVersion();
   if (v === '1.1.1') {
-    const modules = await safeSdk.getModules();
+    const safeSdkV1 = await getSafe({
+      chainID: `0x${(await safeSdk.getChainId()).toString(16)}`,
+      safeAddress: safeSdk.getAddress(),
+      patchV1: true,
+    });
+    const modules = await safeSdkV1.getModules();
     return modules.map(m => m.toLowerCase()).includes(moduleAddress);
   }
-  return safeSdk?.isModuleEnabled(moduleAddress);
+  return safeSdk.isModuleEnabled(moduleAddress);
 };
 
 export const isModuleEnabled = async (chainID, safeAddress, moduleAddress) => {


### PR DESCRIPTION
## GitHub Issue

Fixes #1971 

## Changes

- Adds a workaround to support Gnosis Safe V1.1.1. This version can be used when summoning a Minion Safe using an existing multisig
- Adds a message suggesting DAO Vault owners upgrade their Gnosis Safe to a newer version

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
