### PR TITLE
fix fetching modules from foreign gnosis safe v.1.1.1

### DIFF
--- a/src/utils/gnosis.js
+++ b/src/utils/gnosis.js
@@ -100,12 +100,21 @@ export const isModuleEnabled = async (chainID, safeAddress, moduleAddress) => {
   return isModuleEnabledInternal(safeSdk, moduleAddress);
 };
 
+const getSafeInternal = async ({ chainID, safeAddress }) => {
+  const safeSdk = await getSafe({ chainID, safeAddress });
+  const v = await safeSdk.getContractVersion();
+  if (v === '1.1.1') {
+    return getSafe({ chainID, safeAddress, patchV1: true });
+  }
+  return safeSdk;
+};
+
 export const fetchAmbModule = async (
   ambController, // { chainId, address }
   foreignChainId,
   foreignSafeAddress,
 ) => {
-  const safeSdk = await getSafe({
+  const safeSdk = await getSafeInternal({
     chainID: foreignChainId,
     safeAddress: foreignSafeAddress,
   });


### PR DESCRIPTION
## GitHub Issue

Related to #1971

## Changes

Adds a workaround to support Gnosis Safe V1.1.1. This version can be used when summoning a cross-chain minion using an existing multisig in the foreign network

## Packages Added

None

## Checks

Before making your PR, please check the following:

- [X] Critical lint errors are resolved
- [X] App runs and builds locally
