### PR TITLE
Additional check to make sure cancel minion doesn't show for non-prop

### DIFF
--- a/src/proposalBuilder/unsponsored.jsx
+++ b/src/proposalBuilder/unsponsored.jsx
@@ -216,18 +216,20 @@ const SponsorCard = ({
               Cancel Minion
             </Button>
           )) ||
-          (proposal?.minionAddress && proposal.createdBy === address && (
-            <Button
-              size='sm'
-              fontWeight='700'
-              minW='4rem'
-              variant='outline'
-              onClick={cancelMinion}
-              isLoading={isLoadingTx}
-            >
-              Cancel Minion
-            </Button>
-          ))}
+          (proposal?.minionAddress &&
+            proposal.proposer === proposal.minionAddress &&
+            proposal.createdBy === address && (
+              <Button
+                size='sm'
+                fontWeight='700'
+                minW='4rem'
+                variant='outline'
+                onClick={cancelMinion}
+                isLoading={isLoadingTx}
+              >
+                Cancel Minion
+              </Button>
+            ))}
         {address?.toLowerCase() === proposal?.proposer?.toLowerCase() && (
           <Button
             size='sm'

--- a/src/proposalBuilder/unsponsored.jsx
+++ b/src/proposalBuilder/unsponsored.jsx
@@ -203,7 +203,8 @@ const SponsorCard = ({
           Sponsor {depositData?.deposit && `(${depositData.deposit})`}
         </Button>
         {proposal?.minionAddress &&
-          proposal.proposer === proposal.minionAddress && (
+          proposal.proposer === proposal.minionAddress &&
+          proposal?.createdBy === proposal.minionAddress && (
             <Button
               size='sm'
               fontWeight='700'

--- a/src/proposalBuilder/unsponsored.jsx
+++ b/src/proposalBuilder/unsponsored.jsx
@@ -205,7 +205,7 @@ const SponsorCard = ({
         {(proposal?.minionAddress &&
           proposal.proposer === proposal.minionAddress &&
           proposal.createdBy === proposal.minionAddress) ||
-          (proposal.createdBy === address && (
+          (proposal?.minionAddress && proposal.createdBy === address && (
             <Button
               size='sm'
               fontWeight='700'

--- a/src/proposalBuilder/unsponsored.jsx
+++ b/src/proposalBuilder/unsponsored.jsx
@@ -202,9 +202,10 @@ const SponsorCard = ({
         >
           Sponsor {depositData?.deposit && `(${depositData.deposit})`}
         </Button>
-        {proposal?.minionAddress &&
+        {(proposal?.minionAddress &&
           proposal.proposer === proposal.minionAddress &&
-          proposal?.createdBy === proposal.minionAddress && (
+          proposal.createdBy === proposal.minionAddress) ||
+          (proposal.createdBy === address && (
             <Button
               size='sm'
               fontWeight='700'
@@ -215,8 +216,8 @@ const SponsorCard = ({
             >
               Cancel Minion
             </Button>
-          )}
-        {address?.toLowerCase() === proposal?.createdBy?.toLowerCase() && (
+          ))}
+        {address?.toLowerCase() === proposal?.proposer?.toLowerCase() && (
           <Button
             size='sm'
             fontWeight='700'

--- a/src/proposalBuilder/unsponsored.jsx
+++ b/src/proposalBuilder/unsponsored.jsx
@@ -204,7 +204,18 @@ const SponsorCard = ({
         </Button>
         {(proposal?.minionAddress &&
           proposal.proposer === proposal.minionAddress &&
-          proposal.createdBy === proposal.minionAddress) ||
+          proposal.createdBy === proposal.minionAddress && (
+            <Button
+              size='sm'
+              fontWeight='700'
+              minW='4rem'
+              variant='outline'
+              onClick={cancelMinion}
+              isLoading={isLoadingTx}
+            >
+              Cancel Minion
+            </Button>
+          )) ||
           (proposal?.minionAddress && proposal.createdBy === address && (
             <Button
               size='sm'

--- a/src/proposalBuilder/unsponsored.jsx
+++ b/src/proposalBuilder/unsponsored.jsx
@@ -216,7 +216,7 @@ const SponsorCard = ({
               Cancel Minion
             </Button>
           )}
-        {address?.toLowerCase() === proposal?.proposer?.toLowerCase() && (
+        {address?.toLowerCase() === proposal?.createdBy?.toLowerCase() && (
           <Button
             size='sm'
             fontWeight='700'


### PR DESCRIPTION

## GitHub Issue

#1981 

## Changes

Check if `createdBy` is equal to `minionAddress` in addition to `proposer`. If proposal was not created by minion, don't show cancel minion button

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [ ] Critical lint errors are resolved
- [ ] App runs and builds locally
