### PR TITLE
allow proposer to cancel minion from detail

### DIFF
--- a/src/components/minionCancel.jsx
+++ b/src/components/minionCancel.jsx
@@ -40,8 +40,11 @@ const MinionCancel = ({ proposal }) => {
     daochain === injectedProvider?.currentProvider?.chainId;
 
   useEffect(() => {
-    setIsProposer(proposal?.proposer === address);
-  }, [address, proposal?.proposer]);
+    setIsProposer(
+      proposal?.createdBy === address ||
+        proposal?.createdBy === proposal?.minionAddress,
+    );
+  }, [address, proposal?.proposer, proposal?.createdBy]);
 
   const getMinionAction = () => {
     return (


### PR DESCRIPTION
## GitHub Issue

#2001 

## Changes

Follow same logic as list view by checking if `createdBy` is equal to `address` instead of `proposer`. 

## Packages Added

Brief list of any packages added, and if folks need to rerun `yarn install` to run locally

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs and builds locally
