### PR TITLE
Adds banner notifying of testnet deprecation.

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-// import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Flex, Box, useBreakpointValue } from '@chakra-ui/react';
 
 import { useCustomTheme } from '../contexts/CustomThemeContext';
@@ -8,11 +8,11 @@ import MobileNav from '../nav/mobileNav';
 import { themeImagePath } from '../utils/metadata';
 
 import '../global.css';
-// import NoticeBanner from './noticeBanner';
+import NoticeBanner from './noticeBanner';
 
 const Layout = ({ children, dao }) => {
   const { theme } = useCustomTheme();
-  // const { daochain } = useParams();
+  const { daochain } = useParams();
   const mainNav = useBreakpointValue({
     lg: <DesktopNav dao={dao} />,
     md: <MobileNav dao={dao} />,
@@ -58,7 +58,7 @@ const Layout = ({ children, dao }) => {
         mt={['80px', null, null, '0px']}
         flexDirection='column'
       >
-        {/* {daochain === '0x64' && <NoticeBanner />} */}
+        {(daochain === '0x4' || daochain === '0x5') && <NoticeBanner />}
         {children}
       </Flex>
     </Flex>

--- a/src/components/noticeBanner.jsx
+++ b/src/components/noticeBanner.jsx
@@ -10,8 +10,8 @@ const NoticeBanner = () => {
       </Text>
       <Text fontSize='md'>
         The Rinkeby testnet is nearing end-of-life and our support is moving to
-        Goerli. Please summon any new test DAOs on Goerli and existing DAOs on
-        Rinkeby will no longer be supported in the near future.{' '}
+        Goerli. Please summon new test DAOs on Goerli. DAOs on Rinkeby will not
+        be supported after September 30, 2022.{' '}
         <Link
           color='white'
           href='https://blog.ethereum.org/2022/06/21/testnet-deprecation'

--- a/src/components/noticeBanner.jsx
+++ b/src/components/noticeBanner.jsx
@@ -9,14 +9,15 @@ const NoticeBanner = () => {
         NOTICE
       </Text>
       <Text fontSize='md'>
-        The DAOhaus app isn't currently able to display the most recent onchain
-        data for any Gnosis Chain DAO. This is due to TheGraph subgraph errors.{' '}
+        The Rinkeby testnet is nearing end-of-life and our support is moving to
+        Goerli. Please summon any new test DAOs on Goerli and existing DAOs on
+        Rinkeby will no longer be supported in the near future.{' '}
         <Link
           color='white'
-          href='https://status.thegraph.com/incidents/l3vzzpl87l9w'
+          href='https://blog.ethereum.org/2022/06/21/testnet-deprecation'
           isExternal
         >
-          Monitor the incident here
+          See deprecation announcement here.
           <Icon as={RiExternalLinkLine} ml='2px' mt='-3px' />
         </Link>
       </Text>


### PR DESCRIPTION
 * displays on testnet DAOs

## GitHub Issue

fixes #1956 

## Changes

Show a banner (open to wording changes) notifying users of Rinkeby EOL. Should this show for all users or only for testnet DAOs (currently shows only for Rinkeby or Goerli DAOs). 

![Screenshot from 2022-09-19 12-35-57](https://user-images.githubusercontent.com/408660/191085681-4495c377-299f-4250-ba26-23db514095bd.png)

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs and builds locally
