### PR TITLE
Removing banner after testnet removal

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 import { Flex, Box, useBreakpointValue } from '@chakra-ui/react';
 
 import { useCustomTheme } from '../contexts/CustomThemeContext';
@@ -8,11 +7,9 @@ import MobileNav from '../nav/mobileNav';
 import { themeImagePath } from '../utils/metadata';
 
 import '../global.css';
-import NoticeBanner from './noticeBanner';
 
 const Layout = ({ children, dao }) => {
   const { theme } = useCustomTheme();
-  const { daochain } = useParams();
   const mainNav = useBreakpointValue({
     lg: <DesktopNav dao={dao} />,
     md: <MobileNav dao={dao} />,
@@ -58,9 +55,6 @@ const Layout = ({ children, dao }) => {
         mt={['80px', null, null, '0px']}
         flexDirection='column'
       >
-        {(daochain === '0x4' || daochain === '0x5' || daochain === '0x2a') && (
-          <NoticeBanner />
-        )}
         {children}
       </Flex>
     </Flex>


### PR DESCRIPTION
## GitHub Issue

#1957 

## Changes

This removes the banner that we added to warn users about testnet deprecation.

## Packages Added

N/A

## Checks

Before making your PR, please check the following:

- [x] Critical lint errors are resolved
- [x] App runs and builds locally
